### PR TITLE
quic: allow disabling quinn GSO via QUINN_DISABLE_GSO

### DIFF
--- a/shadowquic/config_examples/client.yaml
+++ b/shadowquic/config_examples/client.yaml
@@ -11,6 +11,7 @@ outbound:
     initial-mtu: 1300
     congestion-control: bbr
     zero-rtt: true
+    gso: true # Enable Quinn Generic Segmentation Offload (GSO)
     over-stream: false  # true for udp over stream, false for udp over datagram
 log-level: "trace"
 

--- a/shadowquic/config_examples/server.yaml
+++ b/shadowquic/config_examples/server.yaml
@@ -11,6 +11,7 @@ inbound:
     alpn: ["h3"]
     congestion-control: bbr
     zero-rtt: true
+    gso: true # Enable Quinn Generic Segmentation Offload (GSO)
 outbound:
     type: direct
     dns-strategy: prefer-ipv4 # or prefer-ipv6, ipv4-only, ipv6-only

--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -196,6 +196,12 @@ pub struct ShadowQuicClientCfg {
     /// Disabled by default.
     #[serde(default = "default_keep_alive_interval")]
     pub keep_alive_interval: u32,
+    /// Enable Quinn Generic Segmentation Offload (GSO).
+    /// Controls [`quinn::TransportConfig::enable_segmentation_offload`]. When supported, GSO reduces
+    /// CPU usage for bulk sends; unsupported environments may see transient startup packet loss.
+    /// Enabled by default
+    #[serde(default = "default_gso")]
+    pub gso: bool,
 
     /// Android Only. the unix socket path for protecting android socket
     #[cfg(target_os = "android")]
@@ -216,6 +222,7 @@ impl Default for ShadowQuicClientCfg {
             over_stream: Default::default(),
             min_mtu: default_min_mtu(),
             keep_alive_interval: default_keep_alive_interval(),
+            gso: default_gso(),
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
         }
@@ -245,6 +252,9 @@ pub fn default_keep_alive_interval() -> u32 {
 }
 pub fn default_rate_limit() -> u64 {
     u64::MAX
+}
+pub fn default_gso() -> bool {
+    true
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
@@ -330,6 +340,12 @@ pub struct ShadowQuicServerCfg {
     /// 1400 is recommended for high packet loss network. default to be 1290
     #[serde(default = "default_min_mtu")]
     pub min_mtu: u16,
+    /// Enable Quinn Generic Segmentation Offload (GSO).
+    /// Controls [`quinn::TransportConfig::enable_segmentation_offload`]. When supported, GSO reduces
+    /// CPU usage for bulk sends; unsupported environments may see transient startup packet loss.
+    /// Enabled by default
+    #[serde(default = "default_gso")]
+    pub gso: bool,
 }
 
 /// Jls upstream configuration
@@ -362,6 +378,7 @@ impl Default for ShadowQuicServerCfg {
             congestion_control: Default::default(),
             initial_mtu: default_initial_mtu(),
             min_mtu: default_min_mtu(),
+            gso: default_gso(),
             server_name: None,
         }
     }


### PR DESCRIPTION
Add an environment variable, `QUINN_DISABLE_GSO`, to disable Quinn’s segmentation offload (GSO) for both client and server transport configurations.

When enabled, a warning is logged to make the behavior explicit.

This allows [tutuicmptunnel-kmod](https://github.com/hrimfaxi/tutuicmptunnel-kmod) to work correctly, as it requires GSO to be disabled.