### PR TITLE
Add Brutal congestion control with human-readable bandwidth config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -94,19 +94,20 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.11"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e4850548ff4a25a77ce3bda7241874e17fb702ea551f0cc62a2dbe052f1272"
+checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
 dependencies = [
  "anstyle",
+ "memchr",
  "unicode-width 0.2.2",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -119,15 +120,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -154,15 +155,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -331,18 +332,46 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
+name = "brutal-core"
+version = "0.1.0"
+source = "git+https://github.com/hrimfaxi/brutal_quinn.git?branch=master#5d87262afe1264ce963c17a762ab11c5adfd2ccf"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "brutal-iroh"
+version = "0.1.0"
+source = "git+https://github.com/hrimfaxi/brutal_quinn.git?branch=master#5d87262afe1264ce963c17a762ab11c5adfd2ccf"
+dependencies = [
+ "brutal-core",
+ "noq-proto",
+ "tracing",
+]
+
+[[package]]
+name = "brutal-jls"
+version = "0.1.0"
+source = "git+https://github.com/hrimfaxi/brutal_quinn.git?branch=master#5d87262afe1264ce963c17a762ab11c5adfd2ccf"
+dependencies = [
+ "brutal-core",
+ "quinn-proto 0.11.10 (git+https://github.com/spongebob888/quinn-jls?tag=quinn-0.11.7-0.3.1)",
+ "tracing",
+]
+
+[[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -373,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -400,10 +429,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -423,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -433,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -445,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -457,15 +497,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -571,6 +611,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -781,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -982,6 +1031,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
 name = "figment"
 version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1078,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1041,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1056,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1066,15 +1133,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1083,15 +1150,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1100,21 +1167,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1124,7 +1191,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1182,8 +1248,24 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1226,7 +1308,7 @@ dependencies = [
  "derive_more",
  "futures",
  "qconnection",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1265,11 +1347,20 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1359,9 +1450,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1374,7 +1465,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1407,7 +1497,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1519,6 +1609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,11 +1672,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -1605,68 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iroh-quinn"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034ed21f34c657a123d39525d948c885aacba59508805e4dd67d71f022e7151b"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
- "pin-project-lite",
- "rustc-hash",
- "rustls 0.23.36",
- "socket2 0.6.2",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "iroh-quinn-proto"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de99ad8adc878ee0e68509ad256152ce23b8bbe45f5539d04e179630aca40a9"
-dependencies = [
- "bytes",
- "derive_more",
- "enum-assoc",
- "getrandom 0.3.4",
- "identity-hash",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls 0.23.36",
- "rustls-pki-types",
- "slab",
- "sorted-index-buffer",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "iroh-quinn-udp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
-dependencies = [
- "cfg_aliases",
- "libc",
- "socket2 0.6.2",
- "tracing",
- "windows-sys 0.61.2",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_ci"
@@ -1691,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1704,7 +1741,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1713,15 +1750,37 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1754,16 +1813,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1882,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -1931,7 +2002,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -1967,7 +2038,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1980,7 +2051,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2013,12 +2084,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "noq"
+version = "0.17.0"
+source = "git+https://github.com/hrimfaxi/iroh_quinn?branch=main#c2103a144cdc61f35bc724f353b3316b91e4be5d"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls 0.23.37",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "0.16.0"
+source = "git+https://github.com/hrimfaxi/iroh_quinn?branch=main#c2103a144cdc61f35bc724f353b3316b91e4be5d"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more",
+ "enum-assoc",
+ "fastbloom",
+ "getrandom 0.4.2",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.10.0",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "0.9.0"
+source = "git+https://github.com/hrimfaxi/iroh_quinn?branch=main#c2103a144cdc61f35bc724f353b3316b91e4be5d"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2036,7 +2166,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "serde",
 ]
 
@@ -2061,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2112,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2136,9 +2266,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot_core"
@@ -2172,9 +2302,9 @@ dependencies = [
  "async-trait",
  "bytes",
  "fast-socks5",
- "quinn",
+ "quinn 0.11.7 (git+https://github.com/spongebob888/quinn-jls?branch=jls-dev)",
  "rcgen",
- "rustls 0.23.25 (git+https://github.com/spongebob888/rustls-jls?branch=jls-dev)",
+ "rustls 0.23.36",
  "shadowquic",
  "thiserror 2.0.18",
  "tokio",
@@ -2185,18 +2315,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2205,15 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "polyval"
@@ -2222,10 +2346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2249,6 +2379,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2320,7 +2460,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2634399a2eca401b140b1e89ce7f326cc816de487e01c76350d9439a7e5cd176"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "derive_more",
  "enum_dispatch",
@@ -2330,8 +2470,8 @@ dependencies = [
  "netdev",
  "nom 8.0.0",
  "qmacro",
- "rand",
- "rustls 0.23.36",
+ "rand 0.9.2",
+ "rustls 0.23.37",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -2346,7 +2486,7 @@ checksum = "8f1d18c9321ffba0ba83316fc4d3ec687a8a6c3d4d3532ed7105c98cba5556b6"
 dependencies = [
  "qbase",
  "qevent",
- "rand",
+ "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2370,7 +2510,7 @@ dependencies = [
  "qrecovery",
  "qunreliable",
  "ring",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -2412,7 +2552,7 @@ dependencies = [
  "qbase",
  "qevent",
  "qudp",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -2444,8 +2584,8 @@ dependencies = [
  "futures",
  "qbase",
  "qevent",
- "rand",
- "rustls 0.23.36",
+ "rand 0.9.2",
+ "rustls 0.23.37",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2461,10 +2601,29 @@ dependencies = [
  "cfg-if",
  "libc",
  "nix 0.30.1",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.7"
+source = "git+https://github.com/spongebob888/quinn-jls?tag=quinn-0.11.7-0.3.1#ca7973771e2dec3e1dda7935a0b9d7ec7f2b0692"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto 0.11.10 (git+https://github.com/spongebob888/quinn-jls?tag=quinn-0.11.7-0.3.1)",
+ "quinn-udp 0.5.10 (git+https://github.com/spongebob888/quinn-jls?tag=quinn-0.11.7-0.3.1)",
+ "rustc-hash",
+ "rustls 0.23.25 (git+https://github.com/spongebob888/rustls-jls?tag=v%2F0.23.25-1.2.1)",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -2475,8 +2634,8 @@ dependencies = [
  "bytes",
  "cfg_aliases",
  "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.11.10 (git+https://github.com/spongebob888/quinn-jls?branch=jls-dev)",
+ "quinn-udp 0.5.10 (git+https://github.com/spongebob888/quinn-jls?branch=jls-dev)",
  "rustc-hash",
  "rustls 0.23.25 (git+https://github.com/spongebob888/rustls-jls?tag=v%2F0.23.25-1.2.0)",
  "socket2 0.5.10",
@@ -2487,21 +2646,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn-jls"
-version = "0.11.7-0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9482d2bf0f78129af2026bfd8fcfcf065d11b70312564332c579cad70194625"
+name = "quinn-proto"
+version = "0.11.10"
+source = "git+https://github.com/spongebob888/quinn-jls?tag=quinn-0.11.7-0.3.1#ca7973771e2dec3e1dda7935a0b9d7ec7f2b0692"
 dependencies = [
  "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto-jls",
- "quinn-udp-jls",
+ "getrandom 0.3.4",
+ "rand 0.9.2",
+ "ring",
  "rustc-hash",
- "rustls-jls",
- "socket2 0.5.10",
+ "rustls 0.23.25 (git+https://github.com/spongebob888/rustls-jls?tag=v%2F0.23.25-1.2.1)",
+ "rustls-pki-types",
+ "slab",
  "thiserror 2.0.18",
- "tokio",
+ "tinyvec",
  "tracing",
  "web-time",
 ]
@@ -2513,7 +2671,7 @@ source = "git+https://github.com/spongebob888/quinn-jls?branch=jls-dev#670e73bdb
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls 0.23.25 (git+https://github.com/spongebob888/rustls-jls?tag=v%2F0.23.25-1.2.0)",
@@ -2526,29 +2684,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn-proto-jls"
-version = "0.11.10-0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7229396f4f070349ef7117efc8efa68f860151039f0a0d0e8a1fa868e815a51c"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "rand",
- "ring",
- "rustc-hash",
- "rustls-jls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
 name = "quinn-udp"
 version = "0.5.10"
-source = "git+https://github.com/spongebob888/quinn-jls?branch=jls-dev#670e73bdb0a4a5d8d49c76f643154ce412bc7dcf"
+source = "git+https://github.com/spongebob888/quinn-jls?tag=quinn-0.11.7-0.3.1#ca7973771e2dec3e1dda7935a0b9d7ec7f2b0692"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2559,10 +2697,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn-udp-jls"
-version = "0.5.10-0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae151daf677cdef4468e4102f7e894bc686bc577a51b7a6c9a534c9f45d18b"
+name = "quinn-udp"
+version = "0.5.10"
+source = "git+https://github.com/spongebob888/quinn-jls?branch=jls-dev#670e73bdb0a4a5d8d49c76f643154ce412bc7dcf"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2587,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2601,6 +2738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2751,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -2639,6 +2793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "rcgen"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,7 +2817,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2705,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -2731,9 +2891,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2755,11 +2915,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2783,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.25"
-source = "git+https://github.com/spongebob888/rustls-jls?branch=jls-dev#2c9e4745dbc69bf925f9b8a37489584b6577dd58"
+source = "git+https://github.com/spongebob888/rustls-jls?tag=v%2F0.23.25-1.2.1#9056e33ebc69ac6b75ca4730fb6d63e2831489fd"
 dependencies = [
  "aes-gcm",
  "once_cell",
@@ -2797,8 +2957,22 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.36"
+source = "git+https://github.com/spongebob888/rustls-jls?branch=jls-dev#459f14c849f4fd5986aeeb80a7f52dca785bf80c"
+dependencies = [
+ "aes-gcm",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -2847,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2890,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2929,11 +3103,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2942,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3046,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3065,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -3082,29 +3256,31 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
+ "brutal-iroh",
+ "brutal-jls",
  "bytes",
  "clap",
  "console-subscriber",
  "educe",
  "fast-socks5",
  "gm-quic",
- "iroh-quinn",
+ "noq",
  "notify",
  "qbase",
  "qevent",
- "quinn-jls",
+ "quinn 0.11.7 (git+https://github.com/spongebob888/quinn-jls?tag=quinn-0.11.7-0.3.1)",
  "qunreliable",
- "rand",
+ "rand 0.9.2",
  "rcgen",
  "ring",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-jls",
  "rustls-native-certs",
  "sendfd",
  "serde",
  "serde-saphyr",
  "shadowquic-macros",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -3141,9 +3317,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -3169,12 +3351,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3230,9 +3412,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3262,7 +3444,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3279,12 +3461,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3391,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3406,15 +3588,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -3422,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3500,9 +3682,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -3517,7 +3699,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -3529,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -3575,6 +3757,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3614,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3654,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3666,9 +3849,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -3805,10 +3988,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3819,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3829,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3842,11 +4034,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -4244,9 +4470,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -4256,6 +4482,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -4326,18 +4634,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4406,6 +4714,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/shadowquic/Cargo.toml
+++ b/shadowquic/Cargo.toml
@@ -22,9 +22,16 @@ tokio = {version = "1.49.0", features = ["io-util", "net","rt","macros","rt-mult
 tracing = "0.1.44"
 time = { version = "=0.3.46", features = ["macros", "local-offset"] }
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt", "ansi", "time", "local-time"]}
-#quinn = { package = "quinn", git = "https://github.com/spongebob888/quinn-jls", tag = "quinn-0.11.7-0.3.1", default-features = false, features = ["runtime-tokio", "rustls-ring"],optional = true}
-quinn = { package = "quinn-jls",version = "0.11.7-0.3.1", default-features = false, features = ["runtime-tokio", "rustls-ring"],optional = true}
+quinn = { package = "quinn", git = "https://github.com/spongebob888/quinn-jls", tag = "quinn-0.11.7-0.3.1", default-features = false, features = ["runtime-tokio", "rustls-ring"],optional = true}
+#quinn = { package = "quinn-jls",version = "0.11.7-0.3.1", default-features = false, features = ["runtime-tokio", "rustls-ring"],optional = true}
+#quinn = { package = "quinn", git = "https://github.com/hrimfaxi/quinn-jls", branch = "brutal", default-features = false, features = ["runtime-tokio", "rustls-ring"], optional = true }
+#quinn = { path = "/home/hrimfaxi/quinn-jls/quinn", default-features = false, features = ["runtime-tokio", "rustls-ring"], optional = true }
 
+
+brutal-iroh = { git = "https://github.com/hrimfaxi/brutal_quinn.git", branch = "master" }
+brutal-jls = { git = "https://github.com/hrimfaxi/brutal_quinn.git", branch = "master" }
+#brutal-iroh = { path = "/home/hrimfaxi/brutal_quinn/brutal-iroh" }
+#brutal-jls = { path = "/home/hrimfaxi/brutal_quinn/brutal-jls"}
 
 #rustls_jls = { package = "rustls", git = "https://github.com/spongebob888/rustls-jls", tag = "v/0.23.25-1.2.1", default-features = false, features = ["std","ring"],optional = true}
 rustls_jls = { package = "rustls-jls", version = "0.23.25-1.2.1", default-features = false, features = ["std","ring"],optional = true}
@@ -46,7 +53,11 @@ qunreliable = { version = "0.4", default-features = false, optional = true}
 rustls = { version = "0.23", default-features = false, features = ["std","ring"], optional = true}
 rustls-native-certs = {version = "0.8.3", optional = true}
 
-iroh-quinn ={ version = "0.16.1",optional = true, default-features = false, features = ["rustls-ring","runtime-tokio"]}
+iroh-quinn = { git = "https://github.com/hrimfaxi/iroh_quinn", branch = "main", package = "noq", optional = true, default-features = false, features = ["rustls-ring", "runtime-tokio"] }
+#iroh-quinn ={ version = "0.16.1",optional = true, default-features = false, features = ["rustls-ring","runtime-tokio"]}
+#iroh-quinn ={ git = "https://github.com/hrimfaxi/iroh_quinn", branch = "brutal", optional = true, default-features = false, features = ["rustls-ring","runtime-tokio"]}
+#iroh-quinn ={ package = "iroh-quinn", path = "/home/hrimfaxi/iroh_quinn/quinn", optional = true, default-features = false, features = ["rustls-ring","runtime-tokio"]}
+
 notify = { version = "8.2.0", features = ["serde"], optional = true}
 arc-swap = { version = "1.8.1", optional = true }
 

--- a/shadowquic/config_examples/client_brutal.yaml
+++ b/shadowquic/config_examples/client_brutal.yaml
@@ -1,0 +1,21 @@
+inbound:
+    type: socks
+    bind-addr: "127.0.0.1:1089"
+outbound:
+    type: shadowquic
+    addr: "127.0.0.1:1443"
+    username: "87654321"
+    password: "12345678"
+    server-name: "cloudflare.com" # must be the same as jls_upstream in server
+    alpn: ["h3"]
+    initial-mtu: 1300
+    congestion-control: 
+       brutal:
+          bandwidth: 100m
+    zero-rtt: true
+    gso: true # Enable Quinn Generic Segmentation Offload (GSO)
+    over-stream: false  # true for udp over stream, false for udp over datagram
+log-level: "trace"
+
+
+

--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -206,15 +206,42 @@ pub fn default_brutal_ack_compensate() -> bool {
     false
 }
 
-#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+/// Congestion control algorithm
+/// Example:
+/// ```yaml
+/// congestion-control: bbr # or cubic, new-reno, brutal
+/// ```
+/// If `brutal` is used, the configuration is like:
+/// ```yaml
+/// congestion-control:
+///   brutal:
+///     bandwidth: 10000000 # default 10000000 bps
+///
+/// For Brutal, the bandwidth is the uploading bandwidth.
+/// If you want to
+/// set the downloading bandwidth,  set the bandwidth of the peer(e.g. it's the server for the client)
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum CongestionControl {
     #[default]
     Bbr,
     Cubic,
     NewReno,
-    Brutal,
+    Brutal(BrutalParams),
 }
+
+impl PartialEq for CongestionControl {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (CongestionControl::Bbr, CongestionControl::Bbr)
+                | (CongestionControl::Cubic, CongestionControl::Cubic)
+                | (CongestionControl::NewReno, CongestionControl::NewReno)
+                | (CongestionControl::Brutal(_), CongestionControl::Brutal(_))
+        )
+    }
+}
+
 /// Configuration of direct outbound
 /// Example:
 /// ```yaml
@@ -268,6 +295,8 @@ impl LogLevel {
 
 #[cfg(test)]
 mod test {
+    use crate::config::{CongestionControl, ShadowQuicClientCfg};
+
     use super::Config;
     #[test]
     fn test() {
@@ -294,5 +323,20 @@ outbound:
 "###;
         let cfg: Result<Config, _> = serde_saphyr::from_str(cfgstr);
         assert!(cfg.is_err());
+    }
+    #[test]
+    fn test_cc() {
+        let cfgstr = r###"
+        username: "test"
+        password: "test"
+        addr: "127.0.0.1:1080"
+        server-name: "localhost"
+        congestion-control: 
+            brutal:
+                bandwidth: 10000000
+
+"###;
+        let cfg: Result<ShadowQuicClientCfg, _> = serde_saphyr::from_str(cfgstr);
+        assert!(cfg.is_ok());
     }
 }

--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -182,13 +182,38 @@ pub fn default_mtu_discovery() -> bool {
     true
 }
 
-#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub fn default_brutal_bandwidth() -> u64 {
+    10_000_000
+}
+
+pub fn default_brutal_cwnd_gain() -> f64 {
+    1.10
+}
+
+pub fn default_brutal_min_window() -> u64 {
+    16 * 1024
+}
+
+pub fn default_brutal_min_ack_rate() -> f64 {
+    0.8
+}
+
+pub fn default_brutal_min_sample_count() -> u64 {
+    50
+}
+
+pub fn default_brutal_ack_compensate() -> bool {
+    false
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum CongestionControl {
     #[default]
     Bbr,
     Cubic,
     NewReno,
+    Brutal,
 }
 /// Configuration of direct outbound
 /// Example:

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use serde::de::{self, Visitor};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 use crate::config::{
@@ -241,12 +241,11 @@ impl Default for ShadowQuicClientCfg {
             mtu_discovery: default_mtu_discovery(),
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
-            brutal: None,
         }
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BrutalParams {
     #[serde(deserialize_with = "deserialize_bps")]
@@ -340,8 +339,4 @@ pub struct ShadowQuicClientCfg {
     #[cfg(target_os = "android")]
     #[serde(default)]
     pub protect_path: Option<std::path::PathBuf>,
-
-    /// Brutal client configuration
-    #[serde(default)]
-    pub brutal: Option<BrutalParams>,
 }

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -1,15 +1,124 @@
 use std::net::SocketAddr;
 
-use serde::Deserialize;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::fmt;
 
 use crate::config::{
-    AuthUser, CongestionControl, default_alpn, default_congestion_control, default_gso,
-    default_initial_mtu, default_keep_alive_interval, default_min_mtu, default_mtu_discovery,
-    default_over_stream, default_zero_rtt,
+    AuthUser, CongestionControl, default_alpn, default_brutal_ack_compensate,
+    default_brutal_bandwidth, default_brutal_cwnd_gain, default_brutal_min_ack_rate,
+    default_brutal_min_sample_count, default_brutal_min_window, default_congestion_control,
+    default_gso, default_initial_mtu, default_keep_alive_interval, default_min_mtu,
+    default_mtu_discovery, default_over_stream, default_zero_rtt,
 };
 
 pub fn default_rate_limit() -> u64 {
     u64::MAX
+}
+
+pub fn parse_bps(input: &str) -> Result<u64, String> {
+    let s = input.trim();
+
+    if s.is_empty() {
+        return Err("empty bandwidth string".to_string());
+    }
+
+    let (num_str, multiplier) = match s.as_bytes().last().copied() {
+        Some(b'K') | Some(b'k') => (&s[..s.len() - 1], 1024f64),
+        Some(b'M') | Some(b'm') => (&s[..s.len() - 1], 1024f64 * 1024f64),
+        Some(b'G') | Some(b'g') => (&s[..s.len() - 1], 1024f64 * 1024f64 * 1024f64),
+        Some(b'0'..=b'9') => (s, 1f64),
+        _ => return Err(format!("invalid bandwidth suffix: {input}")),
+    };
+
+    let value: f64 = num_str
+        .trim()
+        .parse()
+        .map_err(|_| format!("invalid bandwidth number: {input}"))?;
+
+    if !value.is_finite() {
+        return Err(format!("invalid bandwidth number: {input}"));
+    }
+
+    if value < 0.0 {
+        return Err(format!("bandwidth must be non-negative: {input}"));
+    }
+
+    let result = value * multiplier;
+
+    if result > u64::MAX as f64 {
+        return Err(format!("bandwidth value overflow: {input}"));
+    }
+
+    Ok(result.round() as u64)
+}
+
+pub fn deserialize_bps<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct BpsVisitor;
+
+    impl<'de> Visitor<'de> for BpsVisitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("an integer bps value or a string like \"30M\" or \"1.5G\"")
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(value)
+        }
+
+        fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(value as u64)
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if value < 0 {
+                return Err(E::custom("bandwidth must be non-negative"));
+            }
+            Ok(value as u64)
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            parse_bps(value).map_err(E::custom)
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            parse_bps(&value).map_err(E::custom)
+        }
+
+        fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if !value.is_finite() {
+                return Err(E::custom("bandwidth must be finite"));
+            }
+            if value < 0.0 {
+                return Err(E::custom("bandwidth must be non-negative"));
+            }
+            Ok(value.round() as u64)
+        }
+    }
+
+    deserializer.deserialize_any(BpsVisitor)
 }
 
 /// Configuration of shadowquic inbound
@@ -70,6 +179,10 @@ pub struct ShadowQuicServerCfg {
     /// For stable udp network, it's better to disable it and set a proper initial mtu
     #[serde(default = "default_mtu_discovery")]
     pub mtu_discovery: bool,
+
+    /// Brutal server configuration
+    #[serde(default)]
+    pub brutal: Option<BrutalParams>,
 }
 
 /// Jls upstream configuration
@@ -105,6 +218,7 @@ impl Default for ShadowQuicServerCfg {
             server_name: None,
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
+            brutal: None,
         }
     }
 }
@@ -127,6 +241,32 @@ impl Default for ShadowQuicClientCfg {
             mtu_discovery: default_mtu_discovery(),
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
+            brutal: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct BrutalParams {
+    #[serde(deserialize_with = "deserialize_bps")]
+    pub bandwidth: u64,
+    pub min_window: u64,
+    pub cwnd_gain: f64,
+    pub min_ack_rate: f64,
+    pub min_sample_count: u64,
+    pub ack_compensate: bool,
+}
+
+impl Default for BrutalParams {
+    fn default() -> Self {
+        Self {
+            bandwidth: default_brutal_bandwidth(),
+            min_window: default_brutal_min_window(),
+            cwnd_gain: default_brutal_cwnd_gain(),
+            min_ack_rate: default_brutal_min_ack_rate(),
+            min_sample_count: default_brutal_min_sample_count(),
+            ack_compensate: default_brutal_ack_compensate(),
         }
     }
 }
@@ -200,4 +340,8 @@ pub struct ShadowQuicClientCfg {
     #[cfg(target_os = "android")]
     #[serde(default)]
     pub protect_path: Option<std::path::PathBuf>,
+
+    /// Brutal client configuration
+    #[serde(default)]
+    pub brutal: Option<BrutalParams>,
 }

--- a/shadowquic/src/config/sunnyquic.rs
+++ b/shadowquic/src/config/sunnyquic.rs
@@ -3,9 +3,9 @@ use std::{net::SocketAddr, path::PathBuf};
 use serde::Deserialize;
 
 use crate::config::{
-    AuthUser, CongestionControl, default_alpn, default_congestion_control, default_gso,
-    default_initial_mtu, default_keep_alive_interval, default_min_mtu, default_mtu_discovery,
-    default_over_stream, default_zero_rtt,
+    AuthUser, BrutalParams, CongestionControl, default_alpn, default_congestion_control,
+    default_gso, default_initial_mtu, default_keep_alive_interval, default_min_mtu,
+    default_mtu_discovery, default_over_stream, default_zero_rtt,
 };
 
 pub(crate) fn default_multipath_num() -> u32 {
@@ -70,6 +70,10 @@ pub struct SunnyQuicServerCfg {
     /// For stable udp network, it's better to disable it and set a proper initial mtu
     #[serde(default = "default_mtu_discovery")]
     pub mtu_discovery: bool,
+
+    /// Brutal server configuration
+    #[serde(default)]
+    pub brutal: Option<BrutalParams>,
 }
 
 impl Default for SunnyQuicServerCfg {
@@ -88,6 +92,7 @@ impl Default for SunnyQuicServerCfg {
             server_name: "localhost".into(),
             mtu_discovery: default_mtu_discovery(),
             gso: default_gso(),
+            brutal: None,
         }
     }
 }
@@ -113,6 +118,7 @@ impl Default for SunnyQuicClientCfg {
             mtu_discovery: default_mtu_discovery(),
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
+            brutal: None,
         }
     }
 }
@@ -202,6 +208,10 @@ pub struct SunnyQuicClientCfg {
     #[cfg(target_os = "android")]
     #[serde(default)]
     pub protect_path: Option<std::path::PathBuf>,
+
+    /// Brutal client configuration
+    #[serde(default)]
+    pub brutal: Option<BrutalParams>,
 }
 
 type QuicPath = String;

--- a/shadowquic/src/config/sunnyquic.rs
+++ b/shadowquic/src/config/sunnyquic.rs
@@ -118,7 +118,6 @@ impl Default for SunnyQuicClientCfg {
             mtu_discovery: default_mtu_discovery(),
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
-            brutal: None,
         }
     }
 }
@@ -208,10 +207,6 @@ pub struct SunnyQuicClientCfg {
     #[cfg(target_os = "android")]
     #[serde(default)]
     pub protect_path: Option<std::path::PathBuf>,
-
-    /// Brutal client configuration
-    #[serde(default)]
-    pub brutal: Option<BrutalParams>,
 }
 
 type QuicPath = String;

--- a/shadowquic/src/error.rs
+++ b/shadowquic/src/error.rs
@@ -42,3 +42,9 @@ impl From<rustls_jls::Error> for SError {
         SError::RustlsError(err.to_string())
     }
 }
+
+impl From<quinn::rustls::Error> for SError {
+    fn from(err: quinn::rustls::Error) -> Self {
+        SError::RustlsError(err.to_string())
+    }
+}

--- a/shadowquic/src/shadowquic/quinn_wrapper.rs
+++ b/shadowquic/src/shadowquic/quinn_wrapper.rs
@@ -264,8 +264,7 @@ pub fn gen_client_cfg(cfg: &ShadowQuicClientCfg) -> quinn::ClientConfig {
         CongestionControl::Bbr => {
             tp_cfg.congestion_controller_factory(Arc::new(BbrConfig::default()))
         }
-        CongestionControl::Brutal => {
-            let brutal = cfg.brutal.clone().unwrap_or_default();
+        CongestionControl::Brutal(ref brutal) => {
             tracing::info!(?brutal, "using brutal congestion control");
             let brutal_config = BrutalConfig::new(
                 brutal.bandwidth,
@@ -345,9 +344,7 @@ impl QuicServer for Endpoint {
         }
 
         match cfg.congestion_control {
-            CongestionControl::Brutal => {
-                let brutal = cfg.brutal.clone().unwrap_or_default();
-
+            CongestionControl::Brutal(ref brutal) => {
                 tracing::info!(?brutal, "using brutal congestion control");
                 let brutal_config = BrutalConfig::new(
                     brutal.bandwidth,

--- a/shadowquic/src/shadowquic/quinn_wrapper.rs
+++ b/shadowquic/src/shadowquic/quinn_wrapper.rs
@@ -1,20 +1,21 @@
 use std::{io, net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use brutal_jls::BrutalConfig;
 use bytes::Bytes;
+use quinn::rustls::{
+    RootCertStore,
+    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+};
 use quinn::{
     ClientConfig, MtuDiscoveryConfig, SendDatagramError, TransportConfig, VarInt,
     congestion::{BbrConfig, CubicConfig, NewRenoConfig},
     crypto::rustls::QuicClientConfig,
 };
-use rustls_jls::{
-    RootCertStore,
-    pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
-};
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::{debug, error, info, trace, warn};
 
-use rustls_jls::ServerConfig as RustlsServerConfig;
+use quinn::rustls::ServerConfig as RustlsServerConfig;
 
 use quinn::crypto::rustls::QuicServerConfig;
 
@@ -215,12 +216,12 @@ pub fn gen_client_cfg(cfg: &ShadowQuicClientCfg) -> quinn::ClientConfig {
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     };
-    let mut crypto = rustls_jls::ClientConfig::builder()
+    let mut crypto = quinn::rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     crypto.alpn_protocols = cfg.alpn.iter().map(|x| x.to_owned().into_bytes()).collect();
     crypto.enable_early_data = cfg.zero_rtt;
-    crypto.jls_config = rustls_jls::jls::JlsClientConfig::new(&cfg.password, &cfg.username);
+    crypto.jls_config = quinn::rustls::jls::JlsClientConfig::new(&cfg.password, &cfg.username);
     let mut tp_cfg = TransportConfig::default();
 
     let mtudis = if cfg.mtu_discovery {
@@ -263,6 +264,19 @@ pub fn gen_client_cfg(cfg: &ShadowQuicClientCfg) -> quinn::ClientConfig {
         CongestionControl::Bbr => {
             tp_cfg.congestion_controller_factory(Arc::new(BbrConfig::default()))
         }
+        CongestionControl::Brutal => {
+            let brutal = cfg.brutal.clone().unwrap_or_default();
+            tracing::info!(?brutal, "using brutal congestion control");
+            let brutal_config = BrutalConfig::new(
+                brutal.bandwidth,
+                brutal.min_window,
+                brutal.cwnd_gain,
+                brutal.min_ack_rate,
+                brutal.min_sample_count,
+                brutal.ack_compensate,
+            );
+            tp_cfg.congestion_controller_factory(Arc::new(brutal_config))
+        }
     };
     let mut config = ClientConfig::new(Arc::new(
         QuicClientConfig::try_from(crypto).expect("rustls config can't created"),
@@ -281,9 +295,10 @@ impl QuicServer for Endpoint {
         let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
         let cert_der = CertificateDer::from(cert.cert);
         let priv_key = PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
-        crypto = RustlsServerConfig::builder_with_protocol_versions(&[&rustls_jls::version::TLS13])
-            .with_no_client_auth()
-            .with_single_cert(vec![cert_der], PrivateKeyDer::Pkcs8(priv_key))?;
+        crypto =
+            RustlsServerConfig::builder_with_protocol_versions(&[&quinn::rustls::version::TLS13])
+                .with_no_client_auth()
+                .with_single_cert(vec![cert_der], PrivateKeyDer::Pkcs8(priv_key))?;
         crypto.alpn_protocols = cfg
             .alpn
             .iter()
@@ -293,7 +308,7 @@ impl QuicServer for Endpoint {
         crypto.max_early_data_size = if cfg.zero_rtt { u32::MAX } else { 0 };
         crypto.send_half_rtt_data = cfg.zero_rtt;
 
-        let mut jls_config = rustls_jls::jls::JlsServerConfig::default();
+        let mut jls_config = quinn::rustls::jls::JlsServerConfig::default();
         for user in &cfg.users {
             jls_config = jls_config.add_user(user.password.clone(), user.username.clone());
         }
@@ -330,6 +345,20 @@ impl QuicServer for Endpoint {
         }
 
         match cfg.congestion_control {
+            CongestionControl::Brutal => {
+                let brutal = cfg.brutal.clone().unwrap_or_default();
+
+                tracing::info!(?brutal, "using brutal congestion control");
+                let brutal_config = BrutalConfig::new(
+                    brutal.bandwidth,
+                    brutal.min_window,
+                    brutal.cwnd_gain,
+                    brutal.min_ack_rate,
+                    brutal.min_sample_count,
+                    brutal.ack_compensate,
+                );
+                tp_cfg.congestion_controller_factory(Arc::new(brutal_config))
+            }
             CongestionControl::Bbr => {
                 let bbr_config = BbrConfig::default();
                 tp_cfg.congestion_controller_factory(Arc::new(bbr_config))

--- a/shadowquic/src/sunnyquic/iroh_wrapper.rs
+++ b/shadowquic/src/sunnyquic/iroh_wrapper.rs
@@ -332,8 +332,7 @@ pub fn gen_client_cfg(cfg: &SunnyQuicClientCfg) -> iroh_quinn::ClientConfig {
         CongestionControl::Bbr => {
             tp_cfg.congestion_controller_factory(Arc::new(BbrConfig::default()))
         }
-        CongestionControl::Brutal => {
-            let brutal = cfg.brutal.clone().unwrap_or_default();
+        CongestionControl::Brutal(ref brutal) => {
             tracing::info!(?brutal, "using brutal congestion control");
             let brutal_config = BrutalConfig::new(
                 brutal.bandwidth,
@@ -401,9 +400,7 @@ impl QuicServer for Endpoint<SunnyQuicServerCfg> {
             .enable_segmentation_offload(cfg.gso)
             .initial_mtu(cfg.initial_mtu);
         match cfg.congestion_control {
-            CongestionControl::Brutal => {
-                let brutal = cfg.brutal.clone().unwrap_or_default();
-
+            CongestionControl::Brutal(ref brutal) => {
                 tracing::info!(?brutal, "using brutal congestion control");
                 let brutal_config = BrutalConfig::new(
                     brutal.bandwidth,

--- a/shadowquic/src/sunnyquic/iroh_wrapper.rs
+++ b/shadowquic/src/sunnyquic/iroh_wrapper.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use brutal_iroh::BrutalConfig;
 use bytes::Bytes;
 use iroh_quinn::{
     ClientConfig, MtuDiscoveryConfig, SendDatagramError, TransportConfig, VarInt,
@@ -331,6 +332,19 @@ pub fn gen_client_cfg(cfg: &SunnyQuicClientCfg) -> iroh_quinn::ClientConfig {
         CongestionControl::Bbr => {
             tp_cfg.congestion_controller_factory(Arc::new(BbrConfig::default()))
         }
+        CongestionControl::Brutal => {
+            let brutal = cfg.brutal.clone().unwrap_or_default();
+            tracing::info!(?brutal, "using brutal congestion control");
+            let brutal_config = BrutalConfig::new(
+                brutal.bandwidth,
+                brutal.min_window,
+                brutal.cwnd_gain,
+                brutal.min_ack_rate,
+                brutal.min_sample_count,
+                brutal.ack_compensate,
+            );
+            tp_cfg.congestion_controller_factory(Arc::new(brutal_config))
+        }
     };
     let mut config = ClientConfig::new(Arc::new(
         QuicClientConfig::try_from(crypto).expect("rustls config can't created"),
@@ -387,6 +401,20 @@ impl QuicServer for Endpoint<SunnyQuicServerCfg> {
             .enable_segmentation_offload(cfg.gso)
             .initial_mtu(cfg.initial_mtu);
         match cfg.congestion_control {
+            CongestionControl::Brutal => {
+                let brutal = cfg.brutal.clone().unwrap_or_default();
+
+                tracing::info!(?brutal, "using brutal congestion control");
+                let brutal_config = BrutalConfig::new(
+                    brutal.bandwidth,
+                    brutal.min_window,
+                    brutal.cwnd_gain,
+                    brutal.min_ack_rate,
+                    brutal.min_sample_count,
+                    brutal.ack_compensate,
+                );
+                tp_cfg.congestion_controller_factory(Arc::new(brutal_config))
+            }
             CongestionControl::Bbr => {
                 let bbr_config = BbrConfig::default();
                 tp_cfg.congestion_controller_factory(Arc::new(bbr_config))

--- a/shadowquic/tests/parse_bps.rs
+++ b/shadowquic/tests/parse_bps.rs
@@ -1,0 +1,55 @@
+use shadowquic::config::parse_bps;
+
+#[test]
+fn parse_plain_integer() {
+    assert_eq!(parse_bps("3123").unwrap(), 3123);
+    assert_eq!(parse_bps("0").unwrap(), 0);
+    assert_eq!(parse_bps("  42  ").unwrap(), 42);
+}
+
+#[test]
+fn parse_kilo_suffix() {
+    assert_eq!(parse_bps("1K").unwrap(), 1024);
+    assert_eq!(parse_bps("1k").unwrap(), 1024);
+    assert_eq!(parse_bps("1.5K").unwrap(), 1536);
+    assert_eq!(parse_bps("30K").unwrap(), 30 * 1024);
+}
+
+#[test]
+fn parse_mega_suffix() {
+    assert_eq!(parse_bps("1M").unwrap(), 1024 * 1024);
+    assert_eq!(parse_bps("1m").unwrap(), 1024 * 1024);
+    assert_eq!(parse_bps("1.5M").unwrap(), 1572864);
+    assert_eq!(parse_bps("20M").unwrap(), 20 * 1024 * 1024);
+}
+
+#[test]
+fn parse_giga_suffix() {
+    assert_eq!(parse_bps("1G").unwrap(), 1024_u64 * 1024 * 1024);
+    assert_eq!(parse_bps("0.5G").unwrap(), 512_u64 * 1024 * 1024);
+    assert_eq!(parse_bps("2G").unwrap(), 2_u64 * 1024 * 1024 * 1024);
+}
+
+#[test]
+fn parse_rounding() {
+    assert_eq!(parse_bps("1.25K").unwrap(), 1280);
+    assert_eq!(
+        parse_bps("1.1K").unwrap(),
+        (1.1_f64 * 1024.0).round() as u64
+    );
+    assert_eq!(
+        parse_bps("1.9M").unwrap(),
+        (1.9_f64 * 1024.0 * 1024.0).round() as u64
+    );
+}
+
+#[test]
+fn reject_invalid_inputs() {
+    assert!(parse_bps("").is_err());
+    assert!(parse_bps("   ").is_err());
+    assert!(parse_bps("abc").is_err());
+    assert!(parse_bps("20T").is_err());
+    assert!(parse_bps("M").is_err());
+    assert!(parse_bps("-1M").is_err());
+    assert!(parse_bps("1.2.3M").is_err());
+}


### PR DESCRIPTION
This commit introduces the Brutal congestion controller for bandwidth-hint-driven transport, along with ergonomic configuration parsing for bitrate values.

Features:
- Add Brutal variant to CongestionControl enum
- Implement BrutalConfig with BDP-based window calculation
- Add transport parameter negotiation (BrutalPeerBps = 0x173e01)
- Support human-readable bandwidth input: "1M", "1.5G", "30K", etc.
- Client advertises down_bps to server; server falls back to 1Mbps if no hint received
- ACK rate tracking with optional aggressive compensation (disabled by default)
- Conservative defaults: cwnd_gain=1.25, no ack_rate compensation

Design notes:
- Brutal increases cwnd under loss (aggressive compensation), opposite to traditional congestion control. This is intentional behavior.
- Transport parameter only sent when Brutal enabled to minimize fingerprinting.
- Server-side Brutal has no bandwidth config; relies entirely on client advertisement.
- SunnyQuic backend explicitly rejects Brutal (not supported).

Chores:
- Add explicit version to shadowquic-macros dependency