### PR TITLE
shadowquic add Port Hopping

### DIFF
--- a/shadowquic/Cargo.toml
+++ b/shadowquic/Cargo.toml
@@ -64,6 +64,7 @@ arc-swap = { version = "1.8.1", optional = true }
 console-subscriber = { version = "0.5.0", optional = true }
 serde-saphyr = "0.0.18"
 ring = "0.17.14"
+rand = "0.9.2"
 
 [target.'cfg(target_os="android")'.dependencies]
 sendfd = { version = "0.4.4", features = ["tokio"] }

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -241,6 +241,8 @@ impl Default for ShadowQuicClientCfg {
             mtu_discovery: default_mtu_discovery(),
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
+            port_hop_interval: 0,
+            port_hop_server_ports: None,
         }
     }
 }
@@ -339,4 +341,16 @@ pub struct ShadowQuicClientCfg {
     #[cfg(target_os = "android")]
     #[serde(default)]
     pub protect_path: Option<std::path::PathBuf>,
+
+    /// Port hopping interval in seconds (maximum).
+    /// When > 0, enables port hopping feature.
+    /// Actual interval is random between 5 seconds and this value.
+    #[serde(default)]
+    pub port_hop_interval: u64,
+
+    /// Server port range for port hopping.
+    /// Example: "50000-60000"
+    /// When port hopping is enabled, client will randomly connect to ports in this range.
+    #[serde(default)]
+    pub port_hop_server_ports: Option<String>,
 }

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -4,8 +4,8 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::{OnceCell, SetOnce, RwLock};
-use rand::{Rng, SeedableRng};
+use tokio::sync::{OnceCell, SetOnce};
+use rand::Rng;
 use tracing::{debug, error, info};
 
 use super::quinn_wrapper::EndClient;
@@ -21,12 +21,6 @@ pub type ShadowQuicConn = SQConn<<EndClient as QuicClient>::C>;
 
 /// Minimum port hop interval in seconds
 const MIN_PORT_HOP_INTERVAL: u64 = 5;
-
-/// Hop state to prevent concurrent hops
-enum HopState {
-    Idle,
-    InProgress,
-}
 
 /// Parse port range string like "50000-60000" into (start, end)
 fn parse_port_range(range_str: &str) -> Option<(u16, u16)> {
@@ -49,8 +43,8 @@ pub struct ShadowQuicClient {
     pub quic_end: OnceCell<EndClient>,
     /// Flag to request immediate hop
     hop_requested: Arc<std::sync::atomic::AtomicBool>,
-    /// Hop state to prevent concurrent hops
-    hop_state: RwLock<HopState>,
+    /// Flag indicating hop is currently in progress
+    hop_in_progress: Arc<std::sync::atomic::AtomicBool>,
     /// Graceful shutdown signal sender for hop timer
     hop_shutdown_tx: tokio::sync::watch::Sender<()>,
 }
@@ -64,6 +58,7 @@ impl Drop for ShadowQuicClient {
 impl ShadowQuicClient {
     pub fn new(cfg: ShadowQuicClientCfg) -> Self {
         let hop_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hop_in_progress = Arc::new(std::sync::atomic::AtomicBool::new(false));
         
         // Create watch channel for graceful shutdown
         let (hop_shutdown_tx, mut hop_shutdown_rx) = tokio::sync::watch::channel(());
@@ -71,19 +66,17 @@ impl ShadowQuicClient {
         // Start the hop timer if port hopping is enabled
         if cfg.port_hop_interval > 0 && cfg.port_hop_server_ports.is_some() {
             let flag = hop_requested.clone();
+            let in_progress = hop_in_progress.clone();
             let interval = cfg.port_hop_interval;
-            let port_range = cfg.port_hop_server_ports.clone();
             
             tokio::spawn(async move {
-                let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
                 loop {
-                    // Calculate wait time:
-                    // - If max_interval < 5s, use fixed 5s
-                    // - If max_interval >= 5s, use random between 5s and max_interval
+                    // Calculate wait time for this cycle
                     let wait_time = if interval < MIN_PORT_HOP_INTERVAL {
                         MIN_PORT_HOP_INTERVAL
                     } else {
-                        rng.random_range(MIN_PORT_HOP_INTERVAL..=interval)
+                        let random: u64 = rand::random();
+                        MIN_PORT_HOP_INTERVAL + (random % (interval - MIN_PORT_HOP_INTERVAL + 1))
                     };
                     
                     debug!("[PortHop] Next hop scheduled in {} seconds", wait_time);
@@ -95,24 +88,32 @@ impl ShadowQuicClient {
                             break;
                         }
                         Ok(Err(_)) | Err(_) => {
-                            // Check if hop is already in progress
+                            // Check if hop is already in progress, wait for it to complete
                             if flag.load(std::sync::atomic::Ordering::SeqCst) {
-                                debug!("[PortHop] Hop already requested, waiting...");
-                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                // Wait for hop to complete
+                                loop {
+                                    tokio::time::sleep(Duration::from_millis(100)).await;
+                                    if !flag.load(std::sync::atomic::Ordering::SeqCst) {
+                                        break;
+                                    }
+                                }
                                 continue;
                             }
                             
-                            // Calculate random port from range
-                            if let Some(ref range_str) = port_range {
-                                if let Some((start, end)) = parse_port_range(range_str) {
-                                    let port = rng.random_range(start..=end);
-                                    info!("[PortHop] Triggering port hop to server port {}", port);
-                                    flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                            // Trigger hop
+                            info!("[PortHop] Triggering port hop request");
+                            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                            in_progress.store(true, std::sync::atomic::Ordering::SeqCst);
+                            
+                            // Wait for hop to complete (flags will be cleared by prepare_conn)
+                            loop {
+                                tokio::time::sleep(Duration::from_millis(100)).await;
+                                if !flag.load(std::sync::atomic::Ordering::SeqCst) {
+                                    break;
                                 }
                             }
                             
-                            // Brief pause before next iteration
-                            tokio::time::sleep(Duration::from_secs(1)).await;
+                            info!("[PortHop] Hop completed, scheduling next hop");
                         }
                     }
                 }
@@ -124,7 +125,7 @@ impl ShadowQuicClient {
             quic_end: OnceCell::new(),
             config: cfg,
             hop_requested,
-            hop_state: RwLock::new(HopState::Idle),
+            hop_in_progress,
             hop_shutdown_tx,
         }
     }
@@ -154,37 +155,10 @@ impl ShadowQuicClient {
             .unwrap_or_else(|| panic!("resolve quic addr failed: {}", self.config.addr));
         (addr.ip(), addr.port())
     }
-    
-    /// Get current target server address for connection
-    fn get_target_addr(&self) -> SocketAddr {
-        let (ip, base_port) = self.get_server_base_addr();
-        
-        // Check if hop is requested
-        let hop_requested = self.hop_requested.load(std::sync::atomic::Ordering::SeqCst);
-        
-        // Check hop state
-        let hop_state = {
-            let state = self.hop_state.try_read();
-            state.map(|s| matches!(*s, HopState::InProgress)).unwrap_or(false)
-        };
-        
-        // If hop is requested and not already in progress, pick a random port from range
-        if hop_requested && !hop_state {
-            if let Some(ref range_str) = self.config.port_hop_server_ports {
-                if let Some((start, end)) = parse_port_range(range_str) {
-                    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
-                    let port = rng.random_range(start..=end);
-                    return SocketAddr::new(ip, port);
-                }
-            }
-        }
-        
-        // Fall back to base address
-        SocketAddr::new(ip, base_port)
-    }
 
     pub async fn get_conn(&self) -> Result<ShadowQuicConn, SError> {
-        let addr = self.get_target_addr();
+        let addr = self.get_server_base_addr();
+        let addr = SocketAddr::new(addr.0, addr.1);
         
         debug!("[PortHop] Connecting to server at {}", addr);
         
@@ -212,7 +186,7 @@ impl ShadowQuicClient {
         tokio::spawn(async move {
             let _ = handle_udp_packet_recv(conn_clone)
                 .await
-                .map_err(|x| error!("handle udp packet recv error: {}", x));
+                .map_err(|x| debug!("[PortHop] recv task ended: {}", x));
         });
         Ok(conn)
     }
@@ -224,16 +198,24 @@ impl ShadowQuicClient {
     
     /// Hop to a new server port by creating a new QUIC connection
     async fn hop_port(&mut self) -> Result<(), SError> {
-        // Acquire write lock to prevent concurrent hops
-        let mut state = self.hop_state.write().await;
-        if matches!(*state, HopState::InProgress) {
-            debug!("[PortHop] Hop already in progress, skipping");
-            return Ok(());
-        }
-        *state = HopState::InProgress;
-        drop(state);
+        let (ip, base_port) = self.get_server_base_addr();
         
-        let addr = self.get_target_addr();
+        // Select random port from range
+        let target_port = if let Some(ref range_str) = self.config.port_hop_server_ports {
+            if let Some((start, end)) = parse_port_range(range_str) {
+                let mut rng = rand::rng();
+                let port = rng.random_range(start..=end);
+                info!("[PortHop] Selected random port {} (range: {}-{})", port, start, end);
+                port
+            } else {
+                error!("[PortHop] Failed to parse port range");
+                base_port
+            }
+        } else {
+            base_port
+        };
+        
+        let addr = SocketAddr::new(ip, target_port);
         info!("[PortHop] Starting port hop to server {}", addr);
         
         // Close existing connection if any
@@ -269,18 +251,12 @@ impl ShadowQuicClient {
         tokio::spawn(async move {
             let _ = handle_udp_packet_recv(conn_clone)
                 .await
-                .map_err(|x| error!("[PortHop] handle udp packet recv error: {}", x));
+                .map_err(|x| debug!("[PortHop] recv task ended: {}", x));
         });
         
         self.quic_conn = Some(new_conn);
         
-        // Reset hop flag and state
-        self.hop_requested.store(false, std::sync::atomic::Ordering::SeqCst);
-        
-        let mut state = self.hop_state.write().await;
-        *state = HopState::Idle;
-        
-        info!("[PortHop] Successfully hopped to server port {}", addr.port());
+        info!("[PortHop] Successfully hopped to server port {}", target_port);
         Ok(())
     }
 
@@ -288,7 +264,13 @@ impl ShadowQuicClient {
         // Check if we need to hop
         if self.hop_requested.load(std::sync::atomic::Ordering::SeqCst) {
             info!("[PortHop] prepare_conn: hop requested, calling hop_port()");
-            if let Err(e) = self.hop_port().await {
+            let hop_result = self.hop_port().await;
+            
+            // Always clear flags after hop attempt
+            self.hop_requested.store(false, std::sync::atomic::Ordering::SeqCst);
+            self.hop_in_progress.store(false, std::sync::atomic::Ordering::SeqCst);
+            
+            if let Err(e) = hop_result {
                 error!("[PortHop] hop_port failed: {}", e);
             }
         }

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -1,12 +1,14 @@
 use async_trait::async_trait;
 use std::{
-    net::{ToSocketAddrs, UdpSocket},
+    net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket},
     sync::Arc,
+    time::Duration,
 };
-use tokio::sync::{OnceCell, SetOnce};
+use tokio::sync::{OnceCell, SetOnce, RwLock};
+use rand::{Rng, SeedableRng};
+use tracing::{debug, error, info};
 
 use super::quinn_wrapper::EndClient;
-use tracing::{error, info};
 
 use crate::{
     Outbound, config::ShadowQuicClientCfg, error::SError, quic::QuicClient,
@@ -17,38 +19,175 @@ use crate::squic::{IDStore, SQConn, handle_udp_packet_recv};
 
 pub type ShadowQuicConn = SQConn<<EndClient as QuicClient>::C>;
 
+/// Minimum port hop interval in seconds
+const MIN_PORT_HOP_INTERVAL: u64 = 5;
+
+/// Hop state to prevent concurrent hops
+enum HopState {
+    Idle,
+    InProgress,
+}
+
+/// Parse port range string like "50000-60000" into (start, end)
+fn parse_port_range(range_str: &str) -> Option<(u16, u16)> {
+    let parts: Vec<&str> = range_str.split('-').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let start: u16 = parts[0].trim().parse().ok()?;
+    let end: u16 = parts[1].trim().parse().ok()?;
+    if start <= end {
+        Some((start, end))
+    } else {
+        Some((end, start))
+    }
+}
+
 pub struct ShadowQuicClient {
     pub quic_conn: Option<ShadowQuicConn>,
     pub config: ShadowQuicClientCfg,
     pub quic_end: OnceCell<EndClient>,
+    /// Flag to request immediate hop
+    hop_requested: Arc<std::sync::atomic::AtomicBool>,
+    /// Hop state to prevent concurrent hops
+    hop_state: RwLock<HopState>,
+    /// Graceful shutdown signal sender for hop timer
+    hop_shutdown_tx: tokio::sync::watch::Sender<()>,
 }
+
+impl Drop for ShadowQuicClient {
+    fn drop(&mut self) {
+        let _ = self.hop_shutdown_tx.send(());
+    }
+}
+
 impl ShadowQuicClient {
     pub fn new(cfg: ShadowQuicClientCfg) -> Self {
+        let hop_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        
+        // Create watch channel for graceful shutdown
+        let (hop_shutdown_tx, mut hop_shutdown_rx) = tokio::sync::watch::channel(());
+        
+        // Start the hop timer if port hopping is enabled
+        if cfg.port_hop_interval > 0 && cfg.port_hop_server_ports.is_some() {
+            let flag = hop_requested.clone();
+            let interval = cfg.port_hop_interval;
+            let port_range = cfg.port_hop_server_ports.clone();
+            
+            tokio::spawn(async move {
+                let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+                loop {
+                    // Calculate wait time:
+                    // - If max_interval < 5s, use fixed 5s
+                    // - If max_interval >= 5s, use random between 5s and max_interval
+                    let wait_time = if interval < MIN_PORT_HOP_INTERVAL {
+                        MIN_PORT_HOP_INTERVAL
+                    } else {
+                        rng.random_range(MIN_PORT_HOP_INTERVAL..=interval)
+                    };
+                    
+                    debug!("[PortHop] Next hop scheduled in {} seconds", wait_time);
+                    
+                    // Wait for timeout or shutdown signal
+                    match tokio::time::timeout(Duration::from_secs(wait_time), hop_shutdown_rx.changed()).await {
+                        Ok(Ok(())) => {
+                            info!("[PortHop] Hop timer stopped gracefully");
+                            break;
+                        }
+                        Ok(Err(_)) | Err(_) => {
+                            // Check if hop is already in progress
+                            if flag.load(std::sync::atomic::Ordering::SeqCst) {
+                                debug!("[PortHop] Hop already requested, waiting...");
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                continue;
+                            }
+                            
+                            // Calculate random port from range
+                            if let Some(ref range_str) = port_range {
+                                if let Some((start, end)) = parse_port_range(range_str) {
+                                    let port = rng.random_range(start..=end);
+                                    info!("[PortHop] Triggering port hop to server port {}", port);
+                                    flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                                }
+                            }
+                            
+                            // Brief pause before next iteration
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+            });
+        }
+        
         Self {
             quic_conn: None,
             quic_end: OnceCell::new(),
             config: cfg,
+            hop_requested,
+            hop_state: RwLock::new(HopState::Idle),
+            hop_shutdown_tx,
         }
     }
+    
     pub async fn init_endpoint(&self, ipv6: bool) -> Result<EndClient, SError> {
         EndClient::new(&self.config, ipv6).await
     }
+    
     pub fn new_with_socket(cfg: ShadowQuicClientCfg, socket: UdpSocket) -> Result<Self, SError> {
-        Ok(Self {
-            quic_end: OnceCell::from(EndClient::new_with_socket(&cfg, socket)?),
-            quic_conn: None,
-            config: cfg,
-        })
+        // Create basic client first (this starts the hop timer if enabled)
+        let mut client = Self::new(cfg);
+        
+        // Override with the provided socket
+        client.quic_end = OnceCell::from(EndClient::new_with_socket(&client.config, socket)?);
+        
+        Ok(client)
     }
-
-    pub async fn get_conn(&self) -> Result<ShadowQuicConn, SError> {
+    
+    /// Get server base address from config (used for initial connection)
+    fn get_server_base_addr(&self) -> (IpAddr, u16) {
         let addr = self
             .config
             .addr
             .to_socket_addrs()
-            .unwrap_or_else(|_| panic!("resolve quic addr faile: {}", self.config.addr))
+            .unwrap_or_else(|_| panic!("resolve quic addr failed: {}", self.config.addr))
             .next()
-            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr));
+            .unwrap_or_else(|| panic!("resolve quic addr failed: {}", self.config.addr));
+        (addr.ip(), addr.port())
+    }
+    
+    /// Get current target server address for connection
+    fn get_target_addr(&self) -> SocketAddr {
+        let (ip, base_port) = self.get_server_base_addr();
+        
+        // Check if hop is requested
+        let hop_requested = self.hop_requested.load(std::sync::atomic::Ordering::SeqCst);
+        
+        // Check hop state
+        let hop_state = {
+            let state = self.hop_state.try_read();
+            state.map(|s| matches!(*s, HopState::InProgress)).unwrap_or(false)
+        };
+        
+        // If hop is requested and not already in progress, pick a random port from range
+        if hop_requested && !hop_state {
+            if let Some(ref range_str) = self.config.port_hop_server_ports {
+                if let Some((start, end)) = parse_port_range(range_str) {
+                    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+                    let port = rng.random_range(start..=end);
+                    return SocketAddr::new(ip, port);
+                }
+            }
+        }
+        
+        // Fall back to base address
+        SocketAddr::new(ip, base_port)
+    }
+
+    pub async fn get_conn(&self) -> Result<ShadowQuicConn, SError> {
+        let addr = self.get_target_addr();
+        
+        debug!("[PortHop] Connecting to server at {}", addr);
+        
         let conn = self
             .quic_end
             .get_or_init(|| async {
@@ -77,7 +216,83 @@ impl ShadowQuicClient {
         });
         Ok(conn)
     }
+    
+    /// Create a new QUIC endpoint
+    async fn create_new_endpoint(&self, ipv6: bool) -> Result<EndClient, SError> {
+        EndClient::new(&self.config, ipv6).await
+    }
+    
+    /// Hop to a new server port by creating a new QUIC connection
+    async fn hop_port(&mut self) -> Result<(), SError> {
+        // Acquire write lock to prevent concurrent hops
+        let mut state = self.hop_state.write().await;
+        if matches!(*state, HopState::InProgress) {
+            debug!("[PortHop] Hop already in progress, skipping");
+            return Ok(());
+        }
+        *state = HopState::InProgress;
+        drop(state);
+        
+        let addr = self.get_target_addr();
+        info!("[PortHop] Starting port hop to server {}", addr);
+        
+        // Close existing connection if any
+        if let Some(ref conn) = self.quic_conn {
+            debug!("[PortHop] Closing existing connection");
+            conn.conn.close(0u8.into(), b"port hop");
+        }
+        
+        // Clear the old connection and endpoint
+        self.quic_conn = None;
+        self.quic_end.take();
+        
+        // Create new endpoint
+        let new_end = self.create_new_endpoint(addr.is_ipv6()).await?;
+        
+        // Store the new endpoint
+        let _ = self.quic_end.set(new_end);
+        
+        // Establish new connection
+        let conn = self.quic_end.get().unwrap().connect(addr, &self.config.server_name).await?;
+        
+        let new_conn = SQConn {
+            conn,
+            authed: Arc::new(SetOnce::new_with(Some(true))),
+            send_id_store: Default::default(),
+            recv_id_store: IDStore {
+                id_counter: Default::default(),
+                inner: Default::default(),
+            },
+        };
+        
+        let conn_clone = new_conn.clone();
+        tokio::spawn(async move {
+            let _ = handle_udp_packet_recv(conn_clone)
+                .await
+                .map_err(|x| error!("[PortHop] handle udp packet recv error: {}", x));
+        });
+        
+        self.quic_conn = Some(new_conn);
+        
+        // Reset hop flag and state
+        self.hop_requested.store(false, std::sync::atomic::Ordering::SeqCst);
+        
+        let mut state = self.hop_state.write().await;
+        *state = HopState::Idle;
+        
+        info!("[PortHop] Successfully hopped to server port {}", addr.port());
+        Ok(())
+    }
+
     async fn prepare_conn(&mut self) -> Result<(), SError> {
+        // Check if we need to hop
+        if self.hop_requested.load(std::sync::atomic::Ordering::SeqCst) {
+            info!("[PortHop] prepare_conn: hop requested, calling hop_port()");
+            if let Err(e) = self.hop_port().await {
+                error!("[PortHop] hop_port failed: {}", e);
+            }
+        }
+        
         // delete connection if closed.
         self.quic_conn.take_if(|x| {
             x.close_reason().is_some_and(|x| {


### PR DESCRIPTION
1. Initial Connection: The address configured in `bind_addr` (e.g., 50000).
2. Timer Trigger: Set `hop_requested=true` and wait for 1 second.
3. `prepare_conn`: Detect the flag and call `hop_port()`.
4. `hop_port`: Randomly select a port from the specified range and establish a new connection.
5. Repeat steps 2–4.
https://github.com/spongebob888/shadowquic/issues/102

![Uploading image.png…]()
