### PR TITLE
Support configurable TLS cipher suite preference on weak devices

### DIFF
--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -344,6 +344,7 @@ mod test {
     use crate::config::{CongestionControl, ShadowQuicClientCfg};
 
     use super::Config;
+    use super::{CipherSuitePreference, normalize_cipher_suite_preference};
     #[test]
     fn test() {
         let cfgstr = r###"
@@ -389,5 +390,42 @@ outbound:
             }
             _ => panic!("expected brutal congestion control"),
         }
+    }
+
+    #[test]
+    fn normalize_cipher_suite_preference_preserves_first_seen_order_and_removes_duplicates() {
+        let input = vec![
+            CipherSuitePreference::Chacha20Poly1305,
+            CipherSuitePreference::Aes256Gcm,
+            CipherSuitePreference::Chacha20Poly1305,
+            CipherSuitePreference::Aes128Gcm,
+            CipherSuitePreference::Aes256Gcm,
+        ];
+        let normalized = normalize_cipher_suite_preference(&input);
+        assert_eq!(
+            normalized,
+            vec![
+                CipherSuitePreference::Chacha20Poly1305,
+                CipherSuitePreference::Aes256Gcm,
+                CipherSuitePreference::Aes128Gcm,
+            ]
+        );
+    }
+    #[test]
+    fn normalize_cipher_suite_preference_appends_aes128_gcm_when_absent() {
+        let input = vec![
+            CipherSuitePreference::Aes256Gcm,
+            CipherSuitePreference::Chacha20Poly1305,
+            CipherSuitePreference::Aes256Gcm,
+        ];
+        let normalized = normalize_cipher_suite_preference(&input);
+        assert_eq!(
+            normalized,
+            vec![
+                CipherSuitePreference::Aes256Gcm,
+                CipherSuitePreference::Chacha20Poly1305,
+                CipherSuitePreference::Aes128Gcm,
+            ]
+        );
     }
 }

--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use tracing::Level;
+use tracing::{Level, warn};
 
 use crate::{
     Inbound, Manager, Outbound,
@@ -267,6 +267,52 @@ pub enum DnsStrategy {
     PreferIpv6,
     Ipv4Only,
     Ipv6Only,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CipherSuitePreference {
+    Aes128Gcm,
+    Chacha20Poly1305,
+    Aes256Gcm,
+}
+
+pub trait HasCipherSuitePreference {
+    fn has_cipher_suite_preference(&self) -> bool;
+}
+
+pub fn maybe_warn_cipher_suite_on_weak_arch<T: HasCipherSuitePreference>(_cfg: &T) {
+    #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
+    {
+        if !_cfg.has_cipher_suite_preference() {
+            warn!(
+                "No `cipher-suite-preference` configured on MIPS target. \
+                 AES-128-GCM may be significantly slower than ChaCha20-Poly1305 on weak MIPS devices. \
+                 Consider setting `cipher-suite-preference: [\"chacha20-poly1305\", \"aes128-gcm\", \"aes256-gcm\"]`."
+            );
+        }
+    }
+}
+
+pub fn normalize_cipher_suite_preference(
+    cipher_suite_preference: &[CipherSuitePreference],
+) -> Vec<CipherSuitePreference> {
+    let mut out = Vec::new();
+
+    for suite in cipher_suite_preference {
+        if !out.contains(suite) {
+            out.push(suite.clone());
+        }
+    }
+
+    if !out.contains(&CipherSuitePreference::Aes128Gcm) {
+        warn!(
+            "`cipher-suite-preference` does not include `aes128-gcm`; appending it automatically"
+        );
+        out.push(CipherSuitePreference::Aes128Gcm);
+    }
+
+    out
 }
 
 /// Log level of shadowquic

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -349,6 +349,8 @@ pub struct ShadowQuicClientCfg {
 
 impl HasCipherSuitePreference for ShadowQuicClientCfg {
     fn has_cipher_suite_preference(&self) -> bool {
-        self.cipher_suite_preference.is_some()
+        self.cipher_suite_preference
+            .as_ref()
+            .is_some_and(|preferences| !preferences.is_empty())
     }
 }

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -5,11 +5,11 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 use crate::config::{
-    AuthUser, CongestionControl, default_alpn, default_brutal_ack_compensate,
-    default_brutal_bandwidth, default_brutal_cwnd_gain, default_brutal_min_ack_rate,
-    default_brutal_min_sample_count, default_brutal_min_window, default_congestion_control,
-    default_gso, default_initial_mtu, default_keep_alive_interval, default_min_mtu,
-    default_mtu_discovery, default_over_stream, default_zero_rtt,
+    AuthUser, CipherSuitePreference, CongestionControl, HasCipherSuitePreference, default_alpn,
+    default_brutal_ack_compensate, default_brutal_bandwidth, default_brutal_cwnd_gain,
+    default_brutal_min_ack_rate, default_brutal_min_sample_count, default_brutal_min_window,
+    default_congestion_control, default_gso, default_initial_mtu, default_keep_alive_interval,
+    default_min_mtu, default_mtu_discovery, default_over_stream, default_zero_rtt,
 };
 
 pub fn default_rate_limit() -> u64 {
@@ -239,6 +239,7 @@ impl Default for ShadowQuicClientCfg {
             keep_alive_interval: default_keep_alive_interval(),
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
+            cipher_suite_preference: None,
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
         }
@@ -335,8 +336,19 @@ pub struct ShadowQuicClientCfg {
     #[serde(default = "default_mtu_discovery")]
     pub mtu_discovery: bool,
 
+    /// Optional TLS 1.3 cipher suite preference.
+    /// If unset, use rustls/ring default preference order.
+    #[serde(default)]
+    pub cipher_suite_preference: Option<Vec<CipherSuitePreference>>,
+
     /// Android Only. the unix socket path for protecting android socket
     #[cfg(target_os = "android")]
     #[serde(default)]
     pub protect_path: Option<std::path::PathBuf>,
+}
+
+impl HasCipherSuitePreference for ShadowQuicClientCfg {
+    fn has_cipher_suite_preference(&self) -> bool {
+        self.cipher_suite_preference.is_some()
+    }
 }

--- a/shadowquic/src/config/sunnyquic.rs
+++ b/shadowquic/src/config/sunnyquic.rs
@@ -218,7 +218,9 @@ pub struct SunnyQuicClientCfg {
 
 impl HasCipherSuitePreference for SunnyQuicClientCfg {
     fn has_cipher_suite_preference(&self) -> bool {
-        self.cipher_suite_preference.is_some()
+        self.cipher_suite_preference
+            .as_ref()
+            .is_some_and(|preferences| !preferences.is_empty())
     }
 }
 

--- a/shadowquic/src/config/sunnyquic.rs
+++ b/shadowquic/src/config/sunnyquic.rs
@@ -3,9 +3,10 @@ use std::{net::SocketAddr, path::PathBuf};
 use serde::Deserialize;
 
 use crate::config::{
-    AuthUser, BrutalParams, CongestionControl, default_alpn, default_congestion_control,
-    default_gso, default_initial_mtu, default_keep_alive_interval, default_min_mtu,
-    default_mtu_discovery, default_over_stream, default_zero_rtt,
+    AuthUser, BrutalParams, CipherSuitePreference, CongestionControl, HasCipherSuitePreference,
+    default_alpn, default_congestion_control, default_gso, default_initial_mtu,
+    default_keep_alive_interval, default_min_mtu, default_mtu_discovery, default_over_stream,
+    default_zero_rtt,
 };
 
 pub(crate) fn default_multipath_num() -> u32 {
@@ -116,6 +117,7 @@ impl Default for SunnyQuicClientCfg {
             cert_path: Default::default(),
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
+            cipher_suite_preference: None,
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
         }
@@ -203,10 +205,21 @@ pub struct SunnyQuicClientCfg {
     #[serde(default = "default_mtu_discovery")]
     pub mtu_discovery: bool,
 
+    /// Optional TLS 1.3 cipher suite preference.
+    /// If unset, use rustls/ring default preference order.
+    #[serde(default)]
+    pub cipher_suite_preference: Option<Vec<CipherSuitePreference>>,
+
     /// Android Only. the unix socket path for protecting android socket
     #[cfg(target_os = "android")]
     #[serde(default)]
     pub protect_path: Option<std::path::PathBuf>,
+}
+
+impl HasCipherSuitePreference for SunnyQuicClientCfg {
+    fn has_cipher_suite_preference(&self) -> bool {
+        self.cipher_suite_preference.is_some()
+    }
 }
 
 type QuicPath = String;

--- a/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
+++ b/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
@@ -10,17 +10,21 @@ use quinn::rustls::{
 use quinn::{
     ClientConfig, MtuDiscoveryConfig, SendDatagramError, TransportConfig, VarInt,
     congestion::{BbrConfig, CubicConfig, NewRenoConfig},
-    crypto::rustls::QuicClientConfig,
 };
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::{debug, error, info, trace, warn};
 
 use quinn::rustls::ServerConfig as RustlsServerConfig;
 
-use quinn::crypto::rustls::QuicServerConfig;
+use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+
+use quinn::rustls::crypto::ring;
 
 use crate::{
-    config::{CongestionControl, ShadowQuicClientCfg, ShadowQuicServerCfg},
+    config::{
+        CipherSuitePreference, CongestionControl, ShadowQuicClientCfg, ShadowQuicServerCfg,
+        maybe_warn_cipher_suite_on_weak_arch, normalize_cipher_suite_preference,
+    },
     error::SResult,
     quic::{
         MAX_DATAGRAM_WINDOW, MAX_SEND_WINDOW, MAX_STREAM_WINDOW, QuicClient, QuicConnection,
@@ -212,13 +216,40 @@ impl QuicClient for Endpoint {
     type C = Connection;
 }
 
+fn to_quinn_cipher_suite(suite: &CipherSuitePreference) -> quinn::rustls::SupportedCipherSuite {
+    match suite {
+        CipherSuitePreference::Chacha20Poly1305 => {
+            ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256
+        }
+        CipherSuitePreference::Aes128Gcm => ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        CipherSuitePreference::Aes256Gcm => ring::cipher_suite::TLS13_AES_256_GCM_SHA384,
+    }
+}
+
 pub fn gen_client_cfg(cfg: &ShadowQuicClientCfg) -> quinn::ClientConfig {
+    maybe_warn_cipher_suite_on_weak_arch(cfg);
+
     let root_store = RootCertStore {
         roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     };
-    let mut crypto = quinn::rustls::ClientConfig::builder()
+
+    let builder = if let Some(cipher_suite_preference) = &cfg.cipher_suite_preference {
+        let normalized = normalize_cipher_suite_preference(cipher_suite_preference);
+
+        let mut provider = ring::default_provider();
+        provider.cipher_suites = normalized.iter().map(to_quinn_cipher_suite).collect();
+
+        quinn::rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+            .with_protocol_versions(&[&quinn::rustls::version::TLS13])
+            .unwrap()
+    } else {
+        quinn::rustls::ClientConfig::builder()
+    };
+
+    let mut crypto = builder
         .with_root_certificates(root_store)
         .with_no_client_auth();
+
     crypto.alpn_protocols = cfg.alpn.iter().map(|x| x.to_owned().into_bytes()).collect();
     crypto.enable_early_data = cfg.zero_rtt;
     crypto.jls_config = quinn::rustls::jls::JlsClientConfig::new(&cfg.password, &cfg.username);

--- a/shadowquic/src/sunnyquic/iroh_wrapper/wrapper.rs
+++ b/shadowquic/src/sunnyquic/iroh_wrapper/wrapper.rs
@@ -12,10 +12,10 @@ use bytes::Bytes;
 use iroh_quinn::{
     ClientConfig, MtuDiscoveryConfig, SendDatagramError, TransportConfig, VarInt,
     congestion::{BbrConfig, CubicConfig, NewRenoConfig},
-    crypto::rustls::QuicClientConfig,
 };
 use rustls::{
     RootCertStore,
+    crypto::ring,
     pki_types::{CertificateDer, pem::PemObject},
 };
 use socket2::{Domain, Protocol, Socket, Type};
@@ -23,10 +23,13 @@ use tracing::{debug, trace, warn};
 
 use rustls::ServerConfig as RustlsServerConfig;
 
-use iroh_quinn::crypto::rustls::QuicServerConfig;
+use iroh_quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
 
 use crate::{
-    config::{CongestionControl, SunnyQuicClientCfg, SunnyQuicServerCfg},
+    config::{
+        CipherSuitePreference, CongestionControl, SunnyQuicClientCfg, SunnyQuicServerCfg,
+        maybe_warn_cipher_suite_on_weak_arch, normalize_cipher_suite_preference,
+    },
     error::{SError, SResult},
     quic::{
         MAX_DATAGRAM_WINDOW, MAX_SEND_WINDOW, MAX_STREAM_WINDOW, QuicClient, QuicConnection,
@@ -273,7 +276,19 @@ async fn add_extra_path(
     Ok(())
 }
 
+fn to_rustls_cipher_suite(suite: &CipherSuitePreference) -> rustls::SupportedCipherSuite {
+    match suite {
+        CipherSuitePreference::Chacha20Poly1305 => {
+            ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256
+        }
+        CipherSuitePreference::Aes128Gcm => ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        CipherSuitePreference::Aes256Gcm => ring::cipher_suite::TLS13_AES_256_GCM_SHA384,
+    }
+}
+
 pub fn gen_client_cfg(cfg: &SunnyQuicClientCfg) -> iroh_quinn::ClientConfig {
+    maybe_warn_cipher_suite_on_weak_arch(cfg);
+
     let mut root_store = RootCertStore::empty();
     for cert in
         rustls_native_certs::load_native_certs().expect("failed to load OS root certificates")
@@ -288,9 +303,22 @@ pub fn gen_client_cfg(cfg: &SunnyQuicClientCfg) -> iroh_quinn::ClientConfig {
         root_store.add_parsable_certificates(der_cert);
     }
 
-    let mut crypto = rustls::ClientConfig::builder()
+    let builder = if let Some(cipher_suite_preference) = &cfg.cipher_suite_preference {
+        let normalized = normalize_cipher_suite_preference(cipher_suite_preference);
+        let mut provider = ring::default_provider();
+        provider.cipher_suites = normalized.iter().map(to_rustls_cipher_suite).collect();
+
+        rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .unwrap()
+    } else {
+        rustls::ClientConfig::builder()
+    };
+
+    let mut crypto = builder
         .with_root_certificates(root_store)
         .with_no_client_auth();
+
     crypto.alpn_protocols = cfg.alpn.iter().map(|x| x.to_owned().into_bytes()).collect();
     crypto.enable_early_data = cfg.zero_rtt;
     let mut tp_cfg = TransportConfig::default();


### PR DESCRIPTION
Add optional `cipher_suite_preference` support to shadowquic and sunnyquic client configs, allowing users to override the default TLS 1.3 cipher suite order used by rustls/ring.

On weak MIPS targets, emit a warning when no preference is configured, since ChaCha20-Poly1305 may significantly outperform AES-128-GCM. Also normalize the configured list by deduplicating entries and automatically appending `aes128-gcm` when omitted.