### PR TITLE
add configurable client-side port hopping

### DIFF
--- a/shadowquic/Cargo.toml
+++ b/shadowquic/Cargo.toml
@@ -60,6 +60,7 @@ arc-swap = { version = "1.8.1", optional = true }
 console-subscriber = { version = "0.5.0", optional = true }
 serde-saphyr = "0.0.18"
 ring = "0.17.14"
+rand = "0.9.2"
 
 [target.'cfg(target_os="android")'.dependencies]
 sendfd = { version = "0.4.4", features = ["tokio"] }

--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -11,6 +11,8 @@ use crate::{
     sunnyquic::{inbound::SunnyQuicServer, outbound::SunnyQuicClient},
 };
 
+mod port_hop;
+pub use crate::config::port_hop::*;
 mod shadowquic;
 mod sunnyquic;
 pub use crate::config::shadowquic::*;

--- a/shadowquic/src/config/port_hop.rs
+++ b/shadowquic/src/config/port_hop.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use std::time::Duration;
+
 /// Minimum port hop interval in seconds
 pub const MIN_PORT_HOP_INTERVAL: u64 = 5;
 
@@ -100,3 +102,9 @@ mod tests {
         assert!(PortRange::deserialize(de).is_err());
     }
 }
+
+/// How long an old path is kept alive after a hop.
+pub const PORT_HOP_DRAIN_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Maximum number of old paths kept in draining state.
+pub const MAX_DRAINING_PATHS: usize = 8;

--- a/shadowquic/src/config/port_hop.rs
+++ b/shadowquic/src/config/port_hop.rs
@@ -104,7 +104,7 @@ mod tests {
 }
 
 /// How long an old path is kept alive after a hop.
-pub const PORT_HOP_DRAIN_TIMEOUT: Duration = Duration::from_secs(90);
+pub const PORT_HOP_DRAIN_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Maximum number of old paths kept in draining state.
-pub const MAX_DRAINING_PATHS: usize = 8;
+pub const MAX_DRAINING_PATHS: usize = 16;

--- a/shadowquic/src/config/port_hop.rs
+++ b/shadowquic/src/config/port_hop.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+
+/// Minimum port hop interval in seconds
+pub const MIN_PORT_HOP_INTERVAL: u64 = 5;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PortHopCfg {
+    /// port hopping interval in seconds (maximum)
+    /// actual interval is random between 5 seconds and this value
+    pub interval: u64,
+
+    /// server port range for port hopping
+    /// example: "50000-60000"
+    pub range: PortRange,
+}
+
+#[derive(Debug, Clone)]
+pub struct PortRange {
+    pub start: u16,
+    pub end: u16,
+}
+
+/// Parse port range string like "50000-60000" into (start, end)
+pub fn parse_port_range(range_str: &str) -> Option<(u16, u16)> {
+    let parts: Vec<&str> = range_str.split('-').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let start: u16 = parts[0].trim().parse().ok()?;
+    let end: u16 = parts[1].trim().parse().ok()?;
+
+    if start == 0 || end == 0 {
+        return None;
+    }
+
+    Some(if start <= end {
+        (start, end)
+    } else {
+        (end, start)
+    })
+}
+
+impl<'de> Deserialize<'de> for PortRange {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let (start, end) = parse_port_range(&s)
+            .ok_or_else(|| serde::de::Error::custom("invalid port-hop range"))?;
+        Ok(Self { start, end })
+    }
+}
+
+impl Serialize for PortRange {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{}-{}", self.start, self.end))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::{
+        IntoDeserializer,
+        value::{Error as DeError, StrDeserializer},
+    };
+
+    #[test]
+    fn test_parse_port_range_valid_and_normalized() {
+        assert_eq!(parse_port_range("50000-60000"), Some((50000, 60000)));
+        assert_eq!(parse_port_range("60000-50000"), Some((50000, 60000)));
+        assert_eq!(parse_port_range(" 50000 - 60000 "), Some((50000, 60000)));
+    }
+
+    #[test]
+    fn test_parse_port_range_reject_zero() {
+        assert_eq!(parse_port_range("0-60000"), None);
+        assert_eq!(parse_port_range("50000-0"), None);
+    }
+
+    #[test]
+    fn test_port_range_deserialize_and_normalize() {
+        let de: StrDeserializer<'_, DeError> = "60000-50000".into_deserializer();
+        let range = PortRange::deserialize(de).unwrap();
+        assert_eq!(range.start, 50000);
+        assert_eq!(range.end, 60000);
+    }
+
+    #[test]
+    fn test_port_range_deserialize_invalid_string() {
+        let de: StrDeserializer<'_, DeError> = "invalid".into_deserializer();
+        assert!(PortRange::deserialize(de).is_err());
+
+        let de: StrDeserializer<'_, DeError> = "0-60000".into_deserializer();
+        assert!(PortRange::deserialize(de).is_err());
+    }
+}

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -5,11 +5,12 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 use crate::config::{
-    AuthUser, CipherSuitePreference, CongestionControl, HasCipherSuitePreference, default_alpn,
-    default_brutal_ack_compensate, default_brutal_bandwidth, default_brutal_cwnd_gain,
-    default_brutal_min_ack_rate, default_brutal_min_sample_count, default_brutal_min_window,
-    default_congestion_control, default_gso, default_initial_mtu, default_keep_alive_interval,
-    default_min_mtu, default_mtu_discovery, default_over_stream, default_zero_rtt,
+    AuthUser, CipherSuitePreference, CongestionControl, HasCipherSuitePreference, PortHopCfg,
+    default_alpn, default_brutal_ack_compensate, default_brutal_bandwidth,
+    default_brutal_cwnd_gain, default_brutal_min_ack_rate, default_brutal_min_sample_count,
+    default_brutal_min_window, default_congestion_control, default_gso, default_initial_mtu,
+    default_keep_alive_interval, default_min_mtu, default_mtu_discovery, default_over_stream,
+    default_zero_rtt,
 };
 
 pub fn default_rate_limit() -> u64 {
@@ -240,6 +241,7 @@ impl Default for ShadowQuicClientCfg {
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
             cipher_suite_preference: None,
+            port_hop: None,
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
         }
@@ -340,6 +342,9 @@ pub struct ShadowQuicClientCfg {
     /// If unset, use rustls/ring default preference order.
     #[serde(default)]
     pub cipher_suite_preference: Option<Vec<CipherSuitePreference>>,
+
+    #[serde(default)]
+    pub port_hop: Option<PortHopCfg>,
 
     /// Android Only. the unix socket path for protecting android socket
     #[cfg(target_os = "android")]

--- a/shadowquic/src/config/sunnyquic.rs
+++ b/shadowquic/src/config/sunnyquic.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use crate::config::{
     AuthUser, BrutalParams, CipherSuitePreference, CongestionControl, HasCipherSuitePreference,
-    default_alpn, default_congestion_control, default_gso, default_initial_mtu,
+    PortHopCfg, default_alpn, default_congestion_control, default_gso, default_initial_mtu,
     default_keep_alive_interval, default_min_mtu, default_mtu_discovery, default_over_stream,
     default_zero_rtt,
 };
@@ -118,6 +118,7 @@ impl Default for SunnyQuicClientCfg {
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
             cipher_suite_preference: None,
+            port_hop: None,
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
         }
@@ -209,6 +210,9 @@ pub struct SunnyQuicClientCfg {
     /// If unset, use rustls/ring default preference order.
     #[serde(default)]
     pub cipher_suite_preference: Option<Vec<CipherSuitePreference>>,
+
+    #[serde(default)]
+    pub port_hop: Option<PortHopCfg>,
 
     /// Android Only. the unix socket path for protecting android socket
     #[cfg(target_os = "android")]

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -280,14 +280,13 @@ impl ShadowQuicClient {
             .current_addr
             .unwrap_or_else(|| self.resolve_base_addr());
 
-        if self.quic_end.is_some() {
-            let conn = {
-                let end = self
-                    .quic_end
-                    .as_ref()
-                    .expect("quic_end must exist when quic_end.is_some()");
-                self.connect_with_endpoint(end, addr).await?
-            };
+        let conn = if let Some(end) = self.quic_end.as_ref() {
+            Some(self.connect_with_endpoint(end, addr).await?)
+        } else {
+            None
+        };
+
+        if let Some(conn) = conn {
             self.quic_conn = Some(conn);
             self.current_addr = Some(addr);
             return Ok(());

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -1,16 +1,19 @@
 use async_trait::async_trait;
+use rand::Rng;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
-    net::{ToSocketAddrs, UdpSocket},
+    net::{SocketAddr, ToSocketAddrs, UdpSocket},
     sync::Arc,
+    time::Duration,
 };
 use tokio::sync::{OnceCell, SetOnce};
+use tracing::{debug, error, info, warn};
 
 use super::quinn_wrapper::EndClient;
-use tracing::{error, info};
 
 use crate::{
-    Outbound, config::ShadowQuicClientCfg, error::SError, quic::QuicClient,
-    squic::outbound::handle_request,
+    Outbound, config::MIN_PORT_HOP_INTERVAL, config::ShadowQuicClientCfg, error::SError,
+    quic::QuicClient, squic::outbound::handle_request,
 };
 
 use crate::squic::{IDStore, SQConn, handle_udp_packet_recv};
@@ -21,24 +24,84 @@ pub struct ShadowQuicClient {
     pub quic_conn: Option<ShadowQuicConn>,
     pub config: ShadowQuicClientCfg,
     pub quic_end: OnceCell<EndClient>,
+    /// Flag indicating that a port hop should be performed on the next prepare_conn call
+    hop_requested: Arc<AtomicBool>,
+    /// graceful shutdown signal sender for hop timer
+    hop_shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
+
+impl Drop for ShadowQuicClient {
+    fn drop(&mut self) {
+        if let Some(tx) = self.hop_shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+static PORT_HOP_WARN: AtomicBool = AtomicBool::new(false);
+
 impl ShadowQuicClient {
     pub fn new(cfg: ShadowQuicClientCfg) -> Self {
+        let hop_requested = Arc::new(AtomicBool::new(false));
+        let (hop_shutdown_tx, mut hop_shutdown_rx) = tokio::sync::oneshot::channel();
+
+        if let Some(port_hop) = &cfg.port_hop {
+            let hop_requested_clone = hop_requested.clone();
+            let interval = port_hop.interval.max(MIN_PORT_HOP_INTERVAL);
+
+            if !PORT_HOP_WARN.swap(true, Ordering::Relaxed) {
+                warn!(
+                    "port hop enabled: interval {}s, range: {}-{}",
+                    interval, port_hop.range.start, port_hop.range.end
+                );
+            }
+
+            tokio::spawn(async move {
+                let mark_pending = || {
+                    if !hop_requested_clone.swap(true, Ordering::SeqCst) {
+                        debug!("marking port hop as pending");
+                    }
+                };
+
+                mark_pending();
+
+                loop {
+                    let wait_time = {
+                        let mut rng = rand::rng();
+                        rng.random_range(MIN_PORT_HOP_INTERVAL..=interval)
+                    };
+                    debug!("scheduled port hop request in {} seconds", wait_time);
+
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(wait_time)) => {
+                            mark_pending();
+                        }
+                        _ = &mut hop_shutdown_rx => {
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+
         Self {
             quic_conn: None,
             quic_end: OnceCell::new(),
             config: cfg,
+            hop_requested,
+            hop_shutdown_tx: Some(hop_shutdown_tx),
         }
     }
+
     pub async fn init_endpoint(&self, ipv6: bool) -> Result<EndClient, SError> {
         EndClient::new(&self.config, ipv6).await
     }
+
     pub fn new_with_socket(cfg: ShadowQuicClientCfg, socket: UdpSocket) -> Result<Self, SError> {
-        Ok(Self {
-            quic_end: OnceCell::from(EndClient::new_with_socket(&cfg, socket)?),
-            quic_conn: None,
-            config: cfg,
-        })
+        let mut client = Self::new(cfg);
+
+        client.quic_end = OnceCell::from(EndClient::new_with_socket(&client.config, socket)?);
+        Ok(client)
     }
 
     pub async fn get_conn(&self) -> Result<ShadowQuicConn, SError> {
@@ -77,7 +140,85 @@ impl ShadowQuicClient {
         });
         Ok(conn)
     }
+
+    async fn create_new_endpoint(&self, ipv6: bool) -> Result<EndClient, SError> {
+        EndClient::new(&self.config, ipv6).await
+    }
+
+    async fn hop_port(&mut self) -> Result<(), SError> {
+        let base_addr = self
+            .config
+            .addr
+            .to_socket_addrs()
+            .unwrap_or_else(|_| panic!("resolve quic addr faile: {}", self.config.addr))
+            .next()
+            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr));
+
+        let ip = base_addr.ip();
+        let base_port = base_addr.port();
+
+        let target_port = match &self.config.port_hop {
+            Some(port_hop) => {
+                let mut rng = rand::rng();
+                let (start, end) = (port_hop.range.start, port_hop.range.end);
+                let port = rng.random_range(start..=end);
+                debug!("selected random port {} (range: {}-{})", port, start, end);
+                port
+            }
+            None => base_port,
+        };
+
+        let addr = SocketAddr::new(ip, target_port);
+        info!("starting port hop to server {}", addr);
+
+        if let Some(ref conn) = self.quic_conn {
+            conn.conn.close(0u8.into(), b"port hop");
+        }
+
+        self.quic_conn = None;
+        self.quic_end.take();
+
+        let new_end = self.create_new_endpoint(addr.is_ipv6()).await?;
+        let _ = self.quic_end.set(new_end);
+
+        let end = self
+            .quic_end
+            .get()
+            .expect("quic endpoint must be initialized after port hop");
+
+        let conn = end.connect(addr, &self.config.server_name).await?;
+
+        let new_conn = SQConn {
+            conn,
+            authed: Arc::new(SetOnce::new_with(Some(true))),
+            send_id_store: Default::default(),
+            recv_id_store: IDStore {
+                id_counter: Default::default(),
+                inner: Default::default(),
+            },
+        };
+
+        let conn_clone = new_conn.clone();
+        tokio::spawn(async move {
+            let _ = handle_udp_packet_recv(conn_clone)
+                .await
+                .map_err(|x| error!("handle udp packet recv error: {}", x));
+        });
+
+        self.quic_conn = Some(new_conn);
+
+        debug!("port hopped to server port {}", target_port);
+        Ok(())
+    }
+
     async fn prepare_conn(&mut self) -> Result<(), SError> {
+        if self.hop_requested.swap(false, Ordering::SeqCst) {
+            match self.hop_port().await {
+                Ok(()) => {}
+                Err(e) => error!("hop_port failed: {}", e),
+            }
+        }
+
         // delete connection if closed.
         self.quic_conn.take_if(|x| {
             x.close_reason().is_some_and(|x| {

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -4,29 +4,44 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     net::{SocketAddr, ToSocketAddrs, UdpSocket},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
-use tokio::sync::{OnceCell, SetOnce};
+use tokio::sync::SetOnce;
 use tracing::{debug, error, info, warn};
 
 use super::quinn_wrapper::EndClient;
 
 use crate::{
-    Outbound, config::MIN_PORT_HOP_INTERVAL, config::ShadowQuicClientCfg, error::SError,
-    quic::QuicClient, squic::outbound::handle_request,
+    Outbound, config::MAX_DRAINING_PATHS, config::MIN_PORT_HOP_INTERVAL,
+    config::PORT_HOP_DRAIN_TIMEOUT, config::ShadowQuicClientCfg, error::SError, quic::QuicClient,
+    squic::outbound::handle_request,
 };
 
 use crate::squic::{IDStore, SQConn, handle_udp_packet_recv};
 
 pub type ShadowQuicConn = SQConn<<EndClient as QuicClient>::C>;
 
+struct DrainingPath {
+    end: EndClient,
+    conn: ShadowQuicConn,
+    addr: SocketAddr,
+    since: Instant,
+}
+
 pub struct ShadowQuicClient {
+    /// Current active connection used by new requests.
     pub quic_conn: Option<ShadowQuicConn>,
     pub config: ShadowQuicClientCfg,
-    pub quic_end: OnceCell<EndClient>,
-    /// Flag indicating that a port hop should be performed on the next prepare_conn call
+    /// Current active endpoint corresponding to `quic_conn`.
+    pub quic_end: Option<EndClient>,
+    /// Current active remote address.
+    current_addr: Option<SocketAddr>,
+    /// Old paths kept alive temporarily so existing requests can drain.
+    draining: Vec<DrainingPath>,
+
+    /// Flag indicating that a port hop should be performed on the next prepare_conn call.
     hop_requested: Arc<AtomicBool>,
-    /// graceful shutdown signal sender for hop timer
+    /// Graceful shutdown signal sender for hop timer.
     hop_shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
@@ -86,7 +101,9 @@ impl ShadowQuicClient {
 
         Self {
             quic_conn: None,
-            quic_end: OnceCell::new(),
+            quic_end: None,
+            current_addr: None,
+            draining: Vec::new(),
             config: cfg,
             hop_requested,
             hop_shutdown_tx: Some(hop_shutdown_tx),
@@ -99,61 +116,21 @@ impl ShadowQuicClient {
 
     pub fn new_with_socket(cfg: ShadowQuicClientCfg, socket: UdpSocket) -> Result<Self, SError> {
         let mut client = Self::new(cfg);
-
-        client.quic_end = OnceCell::from(EndClient::new_with_socket(&client.config, socket)?);
+        client.quic_end = Some(EndClient::new_with_socket(&client.config, socket)?);
         Ok(client)
     }
 
-    pub async fn get_conn(&self) -> Result<ShadowQuicConn, SError> {
-        let addr = self
-            .config
+    fn resolve_base_addr(&self) -> SocketAddr {
+        self.config
             .addr
             .to_socket_addrs()
             .unwrap_or_else(|_| panic!("resolve quic addr faile: {}", self.config.addr))
             .next()
-            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr));
-        let conn = self
-            .quic_end
-            .get_or_init(|| async {
-                self.init_endpoint(addr.is_ipv6())
-                    .await
-                    .expect("error during initialize quic endpoint")
-            })
-            .await
-            .connect(addr, &self.config.server_name)
-            .await?;
-
-        let conn = SQConn {
-            conn,
-            authed: Arc::new(SetOnce::new_with(Some(true))),
-            send_id_store: Default::default(),
-            recv_id_store: IDStore {
-                id_counter: Default::default(),
-                inner: Default::default(),
-            },
-        };
-        let conn_clone = conn.clone();
-        tokio::spawn(async move {
-            let _ = handle_udp_packet_recv(conn_clone)
-                .await
-                .map_err(|x| error!("handle udp packet recv error: {}", x));
-        });
-        Ok(conn)
+            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr))
     }
 
-    async fn create_new_endpoint(&self, ipv6: bool) -> Result<EndClient, SError> {
-        EndClient::new(&self.config, ipv6).await
-    }
-
-    async fn hop_port(&mut self) -> Result<(), SError> {
-        let base_addr = self
-            .config
-            .addr
-            .to_socket_addrs()
-            .unwrap_or_else(|_| panic!("resolve quic addr faile: {}", self.config.addr))
-            .next()
-            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr));
-
+    fn select_hop_addr(&self) -> SocketAddr {
+        let base_addr = self.resolve_base_addr();
         let ip = base_addr.ip();
         let base_port = base_addr.port();
 
@@ -168,50 +145,174 @@ impl ShadowQuicClient {
             None => base_port,
         };
 
-        let addr = SocketAddr::new(ip, target_port);
-        info!("starting port hop to server {}", addr);
+        SocketAddr::new(ip, target_port)
+    }
 
-        if let Some(ref conn) = self.quic_conn {
-            conn.conn.close(0u8.into(), b"port hop");
-        }
+    fn spawn_recv_task(conn: ShadowQuicConn) {
+        tokio::spawn(async move {
+            let _ = handle_udp_packet_recv(conn)
+                .await
+                .map_err(|x| error!("handle udp packet recv error: {}", x));
+        });
+    }
 
-        self.quic_conn = None;
-        self.quic_end.take();
-
-        let new_end = self.create_new_endpoint(addr.is_ipv6()).await?;
-        let _ = self.quic_end.set(new_end);
-
-        let end = self
-            .quic_end
-            .get()
-            .expect("quic endpoint must be initialized after port hop");
-
-        let conn = end.connect(addr, &self.config.server_name).await?;
-
-        let new_conn = SQConn {
-            conn,
+    fn wrap_conn(raw: <EndClient as QuicClient>::C) -> ShadowQuicConn {
+        SQConn {
+            conn: raw,
             authed: Arc::new(SetOnce::new_with(Some(true))),
             send_id_store: Default::default(),
             recv_id_store: IDStore {
                 id_counter: Default::default(),
                 inner: Default::default(),
             },
-        };
+        }
+    }
 
-        let conn_clone = new_conn.clone();
-        tokio::spawn(async move {
-            let _ = handle_udp_packet_recv(conn_clone)
-                .await
-                .map_err(|x| error!("handle udp packet recv error: {}", x));
+    async fn connect_with_endpoint(
+        &self,
+        end: &EndClient,
+        addr: SocketAddr,
+    ) -> Result<ShadowQuicConn, SError> {
+        let raw = end.connect(addr, &self.config.server_name).await?;
+        let conn = Self::wrap_conn(raw);
+        Self::spawn_recv_task(conn.clone());
+        Ok(conn)
+    }
+
+    async fn build_path(&self, addr: SocketAddr) -> Result<(EndClient, ShadowQuicConn), SError> {
+        let end = self.init_endpoint(addr.is_ipv6()).await?;
+        let conn = self.connect_with_endpoint(&end, addr).await?;
+        Ok((end, conn))
+    }
+
+    fn cleanup_draining(&mut self) {
+        self.draining.retain(|path| {
+            let _keep_endpoint_alive = &path.end;
+
+            if let Some(reason) = path.conn.close_reason() {
+                debug!(
+                    "drained quic connection to {} closed due to {}",
+                    path.addr, reason
+                );
+                return false;
+            }
+
+            if path.since.elapsed() >= PORT_HOP_DRAIN_TIMEOUT {
+                debug!(
+                    "closing drained quic connection to {} after {:?}",
+                    path.addr, PORT_HOP_DRAIN_TIMEOUT
+                );
+                path.conn.conn.close(0u8.into(), b"port hop drain timeout");
+                return false;
+            }
+
+            true
         });
 
-        self.quic_conn = Some(new_conn);
+        while self.draining.len() > MAX_DRAINING_PATHS {
+            let old = self.draining.remove(0);
+            debug!(
+                "closing oldest drained quic connection to {} because draining set exceeds {}",
+                old.addr, MAX_DRAINING_PATHS
+            );
+            old.conn
+                .conn
+                .close(0u8.into(), b"port hop draining overflow");
+        }
+    }
 
-        debug!("port hopped to server port {}", target_port);
+    pub async fn get_conn(&self) -> Result<ShadowQuicConn, SError> {
+        self.quic_conn
+            .clone()
+            .ok_or_else(|| std::io::Error::other("quic connection not prepared").into())
+    }
+
+    async fn hop_port(&mut self) -> Result<(), SError> {
+        let addr = self.select_hop_addr();
+        info!("starting soft port hop to server {}", addr);
+
+        // 1. Build new path first. If this fails, the old path remains intact.
+        let (new_end, new_conn) = self.build_path(addr).await?;
+
+        // 2. Move old active path into draining instead of closing it immediately.
+        if let Some(old_conn) = self.quic_conn.take() {
+            if let Some(old_end) = self.quic_end.take() {
+                let old_addr = self
+                    .current_addr
+                    .unwrap_or_else(|| self.resolve_base_addr());
+                debug!("moving old quic path {} into draining set", old_addr);
+
+                self.draining.push(DrainingPath {
+                    end: old_end,
+                    conn: old_conn,
+                    addr: old_addr,
+                    since: Instant::now(),
+                });
+            } else {
+                // Should not normally happen, but if it does, we cannot keep the old path alive safely.
+                warn!(
+                    "active quic connection exists without endpoint; closing old path during hop"
+                );
+                old_conn
+                    .conn
+                    .close(0u8.into(), b"port hop missing endpoint");
+            }
+        }
+
+        // 3. Switch new path to active.
+        self.quic_end = Some(new_end);
+        self.quic_conn = Some(new_conn);
+        self.current_addr = Some(addr);
+
+        // 4. Opportunistic cleanup.
+        self.cleanup_draining();
+
+        debug!("soft port hopped to server {}", addr);
+        Ok(())
+    }
+
+    async fn ensure_active_conn(&mut self) -> Result<(), SError> {
+        if self.quic_conn.is_some() {
+            return Ok(());
+        }
+
+        let addr = self
+            .current_addr
+            .unwrap_or_else(|| self.resolve_base_addr());
+
+        if self.quic_end.is_some() {
+            let conn = {
+                let end = self
+                    .quic_end
+                    .as_ref()
+                    .expect("quic_end must exist when quic_end.is_some()");
+                self.connect_with_endpoint(end, addr).await?
+            };
+            self.quic_conn = Some(conn);
+            self.current_addr = Some(addr);
+            return Ok(());
+        }
+
+        let (end, conn) = self.build_path(addr).await?;
+        self.quic_end = Some(end);
+        self.quic_conn = Some(conn);
+        self.current_addr = Some(addr);
         Ok(())
     }
 
     async fn prepare_conn(&mut self) -> Result<(), SError> {
+        // Clean up old drained paths first.
+        self.cleanup_draining();
+
+        // If active connection is already closed, drop the active path.
+        let active_closed_reason = self.quic_conn.as_ref().and_then(|x| x.close_reason());
+
+        if let Some(reason) = active_closed_reason {
+            debug!("active quic connection closed due to {}", reason);
+            self.quic_conn = None;
+        }
+
+        // Process pending hop request using make-before-break.
         if self.hop_requested.swap(false, Ordering::SeqCst) {
             match self.hop_port().await {
                 Ok(()) => {}
@@ -219,28 +320,21 @@ impl ShadowQuicClient {
             }
         }
 
-        // delete connection if closed.
-        self.quic_conn.take_if(|x| {
-            x.close_reason().is_some_and(|x| {
-                info!("quic connection closed due to {}", x);
-                true
-            })
-        });
-        // Creating new connectin
-        if self.quic_conn.is_none() {
-            self.quic_conn = Some(self.get_conn().await?);
-        }
+        // Ensure there is an active connection.
+        self.ensure_active_conn().await?;
+
         Ok(())
     }
 }
+
 #[async_trait]
 impl Outbound for ShadowQuicClient {
     async fn handle(&mut self, req: crate::ProxyRequest) -> Result<(), crate::error::SError> {
         self.prepare_conn().await?;
 
-        let conn = self.quic_conn.as_mut().unwrap().clone();
-
+        let conn = self.quic_conn.as_ref().unwrap().clone();
         let over_stream = self.config.over_stream;
+
         handle_request(req, conn, over_stream).await?;
         Ok(())
     }

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -73,9 +73,7 @@ impl ShadowQuicClient {
 
             tokio::spawn(async move {
                 let mark_pending = || {
-                    if !hop_requested_clone.swap(true, Ordering::SeqCst) {
-                        debug!("marking port hop as pending");
-                    }
+                    hop_requested_clone.swap(true, Ordering::SeqCst);
                 };
 
                 mark_pending();
@@ -85,7 +83,7 @@ impl ShadowQuicClient {
                         let mut rng = rand::rng();
                         rng.random_range(MIN_PORT_HOP_INTERVAL..=interval)
                     };
-                    debug!("scheduled port hop request in {} seconds", wait_time);
+                    // debug!("scheduled port hop request in {} seconds", wait_time);
 
                     tokio::select! {
                         _ = tokio::time::sleep(Duration::from_secs(wait_time)) => {
@@ -138,9 +136,7 @@ impl ShadowQuicClient {
             Some(port_hop) => {
                 let mut rng = rand::rng();
                 let (start, end) = (port_hop.range.start, port_hop.range.end);
-                let port = rng.random_range(start..=end);
-                debug!("selected random port {} (range: {}-{})", port, start, end);
-                port
+                rng.random_range(start..=end)
             }
             None => base_port,
         };

--- a/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
+++ b/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
@@ -32,6 +32,8 @@ use crate::{
     },
 };
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 pub type Connection = quinn::Connection;
 pub struct Endpoint {
     inner: quinn::Endpoint,
@@ -44,6 +46,8 @@ impl Deref for Endpoint {
         &self.inner
     }
 }
+
+static GSO_WARN: AtomicBool = AtomicBool::new(false);
 
 pub use Endpoint as EndClient;
 pub use Endpoint as EndServer;
@@ -272,7 +276,7 @@ pub fn gen_client_cfg(cfg: &ShadowQuicClientCfg) -> quinn::ClientConfig {
         .initial_mtu(cfg.initial_mtu)
         .enable_segmentation_offload(cfg.gso);
 
-    if !cfg.gso {
+    if !cfg.gso && !GSO_WARN.swap(true, Ordering::Relaxed) {
         tracing::warn!("disabling QUIC segmentation offload (GSO)");
     }
 
@@ -370,7 +374,7 @@ impl QuicServer for Endpoint {
             .initial_mtu(cfg.initial_mtu)
             .enable_segmentation_offload(cfg.gso);
 
-        if !cfg.gso {
+        if !cfg.gso && !GSO_WARN.swap(true, Ordering::Relaxed) {
             tracing::warn!("disabling QUIC segmentation offload (GSO)");
         }
 

--- a/shadowquic/src/sunnyquic/outbound.rs
+++ b/shadowquic/src/sunnyquic/outbound.rs
@@ -1,15 +1,19 @@
 use async_trait::async_trait;
+use rand::Rng;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
-    net::{ToSocketAddrs, UdpSocket},
+    net::{SocketAddr, ToSocketAddrs, UdpSocket},
     sync::Arc,
+    time::Duration,
 };
 use tokio::sync::{OnceCell, SetOnce};
 
 use super::EndClient;
-use tracing::{error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     Outbound,
+    config::MIN_PORT_HOP_INTERVAL,
     config::SunnyQuicClientCfg,
     error::SError,
     quic::{QuicClient, QuicConnection},
@@ -25,24 +29,84 @@ pub struct SunnyQuicClient {
     pub quic_conn: Option<SunnyQuicConn>,
     pub config: SunnyQuicClientCfg,
     pub quic_end: OnceCell<EndClient>,
+    /// Flag indicating that a port hop should be performed on the next prepare_conn call
+    hop_requested: Arc<AtomicBool>,
+    /// graceful shutdown signal sender for hop timer
+    hop_shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
+
+impl Drop for SunnyQuicClient {
+    fn drop(&mut self) {
+        if let Some(tx) = self.hop_shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+static PORT_HOP_WARN: AtomicBool = AtomicBool::new(false);
+
 impl SunnyQuicClient {
     pub fn new(cfg: SunnyQuicClientCfg) -> Self {
+        let hop_requested = Arc::new(AtomicBool::new(false));
+        let (hop_shutdown_tx, mut hop_shutdown_rx) = tokio::sync::oneshot::channel();
+
+        if let Some(port_hop) = &cfg.port_hop {
+            let hop_requested_clone = hop_requested.clone();
+            let interval = port_hop.interval.max(MIN_PORT_HOP_INTERVAL);
+
+            if !PORT_HOP_WARN.swap(true, Ordering::Relaxed) {
+                warn!(
+                    "port hop enabled: interval {}s, range: {}-{}",
+                    interval, port_hop.range.start, port_hop.range.end
+                );
+            }
+
+            tokio::spawn(async move {
+                let mark_pending = || {
+                    if !hop_requested_clone.swap(true, Ordering::SeqCst) {
+                        debug!("marking port hop as pending");
+                    }
+                };
+
+                mark_pending();
+
+                loop {
+                    let wait_time = {
+                        let mut rng = rand::rng();
+                        rng.random_range(MIN_PORT_HOP_INTERVAL..=interval)
+                    };
+                    debug!("scheduled port hop request in {} seconds", wait_time);
+
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(wait_time)) => {
+                            mark_pending();
+                        }
+                        _ = &mut hop_shutdown_rx => {
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+
         Self {
             quic_conn: None,
             quic_end: OnceCell::new(),
             config: cfg,
+            hop_requested,
+            hop_shutdown_tx: Some(hop_shutdown_tx),
         }
     }
+
     pub async fn init_endpoint(&self, ipv6: bool) -> Result<EndClient, SError> {
         EndClient::new(&self.config, ipv6).await
     }
+
     pub fn new_with_socket(cfg: SunnyQuicClientCfg, socket: UdpSocket) -> Result<Self, SError> {
-        Ok(Self {
-            quic_end: OnceCell::from(EndClient::new_with_socket(&cfg, socket)?),
-            quic_conn: None,
-            config: cfg,
-        })
+        let mut client = Self::new(cfg);
+
+        client.quic_end = OnceCell::from(EndClient::new_with_socket(&client.config, socket)?);
+        Ok(client)
     }
 
     pub async fn get_conn(&self) -> Result<SunnyQuicConn, SError> {
@@ -90,7 +154,84 @@ impl SunnyQuicClient {
         });
         Ok(conn)
     }
+
+    async fn hop_port(&mut self) -> Result<(), SError> {
+        let base_addr = self
+            .config
+            .addr
+            .to_socket_addrs()
+            .unwrap_or_else(|_| panic!("resolve quic addr faile: {}", self.config.addr))
+            .next()
+            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr));
+
+        let ip = base_addr.ip();
+        let base_port = base_addr.port();
+
+        let target_port = match &self.config.port_hop {
+            Some(port_hop) => {
+                let mut rng = rand::rng();
+                let (start, end) = (port_hop.range.start, port_hop.range.end);
+                let port = rng.random_range(start..=end);
+                debug!("selected random port {} (range: {}-{})", port, start, end);
+                port
+            }
+            None => base_port,
+        };
+
+        let addr = SocketAddr::new(ip, target_port);
+        info!("starting port hop to server {}", addr);
+
+        if let Some(ref conn) = self.quic_conn {
+            conn.conn.close(0u8.into(), b"port hop");
+        }
+
+        self.quic_conn = None;
+        self.quic_end.take();
+
+        let end = match self.init_endpoint(true).await {
+            Ok(ep) => ep,
+            Err(_) => self.init_endpoint(false).await?,
+        };
+        let _ = self.quic_end.set(end);
+
+        let end = self
+            .quic_end
+            .get()
+            .expect("quic endpoint must be initialized after port hop");
+
+        let conn = QuicClient::connect(end, addr, &self.config.server_name).await?;
+
+        let new_conn = SQConn {
+            conn,
+            authed: Arc::new(SetOnce::new()),
+            send_id_store: Default::default(),
+            recv_id_store: IDStore {
+                id_counter: Default::default(),
+                inner: Default::default(),
+            },
+        };
+
+        let conn_clone = new_conn.clone();
+        tokio::spawn(async move {
+            let _ = handle_udp_packet_recv(conn_clone)
+                .await
+                .map_err(|x| error!("handle udp packet recv error: {}", x));
+        });
+
+        self.quic_conn = Some(new_conn);
+
+        debug!("port hopped to server port {}", target_port);
+        Ok(())
+    }
+
     async fn prepare_conn(&mut self) -> Result<(), SError> {
+        if self.hop_requested.swap(false, Ordering::SeqCst) {
+            match self.hop_port().await {
+                Ok(()) => {}
+                Err(e) => error!("hop_port failed: {}", e),
+            }
+        }
+
         // delete connection if closed.
         self.quic_conn.take_if(|x| {
             QuicConnection::close_reason(&x.conn).is_some_and(|x| {

--- a/shadowquic/src/sunnyquic/outbound.rs
+++ b/shadowquic/src/sunnyquic/outbound.rs
@@ -4,17 +4,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     net::{SocketAddr, ToSocketAddrs, UdpSocket},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
-use tokio::sync::{OnceCell, SetOnce};
+use tokio::sync::SetOnce;
 
 use super::EndClient;
 use tracing::{debug, error, info, warn};
 
 use crate::{
     Outbound,
-    config::MIN_PORT_HOP_INTERVAL,
-    config::SunnyQuicClientCfg,
+    config::{
+        MAX_DRAINING_PATHS, MIN_PORT_HOP_INTERVAL, PORT_HOP_DRAIN_TIMEOUT, SunnyQuicClientCfg,
+    },
     error::SError,
     quic::{QuicClient, QuicConnection},
     squic::{auth_sunny, outbound::handle_request},
@@ -25,10 +26,20 @@ use crate::squic::{IDStore, SQConn, handle_udp_packet_recv};
 
 pub type SunnyQuicConn = SQConn<<EndClient as QuicClient>::C>;
 
+struct DrainingPath {
+    end: EndClient,
+    conn: SunnyQuicConn,
+    addr: SocketAddr,
+    since: Instant,
+}
+
 pub struct SunnyQuicClient {
     pub quic_conn: Option<SunnyQuicConn>,
     pub config: SunnyQuicClientCfg,
-    pub quic_end: OnceCell<EndClient>,
+    pub quic_end: Option<EndClient>,
+    current_addr: Option<SocketAddr>,
+    draining: Vec<DrainingPath>,
+
     /// Flag indicating that a port hop should be performed on the next prepare_conn call
     hop_requested: Arc<AtomicBool>,
     /// graceful shutdown signal sender for hop timer
@@ -91,7 +102,9 @@ impl SunnyQuicClient {
 
         Self {
             quic_conn: None,
-            quic_end: OnceCell::new(),
+            quic_end: None,
+            current_addr: None,
+            draining: Vec::new(),
             config: cfg,
             hop_requested,
             hop_shutdown_tx: Some(hop_shutdown_tx),
@@ -104,66 +117,21 @@ impl SunnyQuicClient {
 
     pub fn new_with_socket(cfg: SunnyQuicClientCfg, socket: UdpSocket) -> Result<Self, SError> {
         let mut client = Self::new(cfg);
-
-        client.quic_end = OnceCell::from(EndClient::new_with_socket(&client.config, socket)?);
+        client.quic_end = Some(EndClient::new_with_socket(&client.config, socket)?);
         Ok(client)
     }
 
-    pub async fn get_conn(&self) -> Result<SunnyQuicConn, SError> {
-        let addr = self
-            .config
+    fn resolve_base_addr(&self) -> SocketAddr {
+        self.config
             .addr
             .to_socket_addrs()
             .unwrap_or_else(|_| panic!("resolve quic addr faile: {}", self.config.addr))
             .next()
-            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr));
-        let end = self
-            .quic_end
-            .get_or_init(|| async {
-                match self.init_endpoint(true).await {
-                    Ok(ep) => ep,
-                    Err(_) => self
-                        .init_endpoint(false)
-                        .await
-                        .expect("error during initialize quic endpoint"),
-                }
-            })
-            .await;
-        let conn = QuicClient::connect(end, addr, &self.config.server_name).await?;
-
-        let conn = SQConn {
-            conn,
-            authed: Arc::new(SetOnce::new()),
-            send_id_store: Default::default(),
-            recv_id_store: IDStore {
-                id_counter: Default::default(),
-                inner: Default::default(),
-            },
-        };
-
-        let username = self.config.username.clone();
-        let password = self.config.password.clone();
-        let conn_clone = conn.clone();
-        tokio::spawn(async move {
-            let _ = auth_sunny(&conn_clone, gen_sunny_user_hash(&username, &password))
-                .await
-                .map_err(|x| error!("authentication failed: {}", x));
-            let _ = handle_udp_packet_recv(conn_clone)
-                .await
-                .map_err(|x| error!("handle udp packet recv error: {}", x));
-        });
-        Ok(conn)
+            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr))
     }
 
-    async fn hop_port(&mut self) -> Result<(), SError> {
-        let base_addr = self
-            .config
-            .addr
-            .to_socket_addrs()
-            .unwrap_or_else(|_| panic!("resolve quic addr faile: {}", self.config.addr))
-            .next()
-            .unwrap_or_else(|| panic!("resolve quic addr faile: {}", self.config.addr));
-
+    fn select_hop_addr(&self) -> SocketAddr {
+        let base_addr = self.resolve_base_addr();
         let ip = base_addr.ip();
         let base_port = base_addr.port();
 
@@ -178,53 +146,192 @@ impl SunnyQuicClient {
             None => base_port,
         };
 
-        let addr = SocketAddr::new(ip, target_port);
-        info!("starting port hop to server {}", addr);
+        SocketAddr::new(ip, target_port)
+    }
 
-        if let Some(ref conn) = self.quic_conn {
-            conn.conn.close(0u8.into(), b"port hop");
+    async fn build_endpoint(&self) -> Result<EndClient, SError> {
+        match self.init_endpoint(true).await {
+            Ok(ep) => Ok(ep),
+            Err(_) => self.init_endpoint(false).await,
         }
+    }
 
-        self.quic_conn = None;
-        self.quic_end.take();
-
-        let end = match self.init_endpoint(true).await {
-            Ok(ep) => ep,
-            Err(_) => self.init_endpoint(false).await?,
-        };
-        let _ = self.quic_end.set(end);
-
-        let end = self
-            .quic_end
-            .get()
-            .expect("quic endpoint must be initialized after port hop");
-
-        let conn = QuicClient::connect(end, addr, &self.config.server_name).await?;
-
-        let new_conn = SQConn {
-            conn,
+    fn wrap_conn(raw: <EndClient as QuicClient>::C) -> SunnyQuicConn {
+        SQConn {
+            conn: raw,
             authed: Arc::new(SetOnce::new()),
             send_id_store: Default::default(),
             recv_id_store: IDStore {
                 id_counter: Default::default(),
                 inner: Default::default(),
             },
-        };
+        }
+    }
 
-        let conn_clone = new_conn.clone();
+    fn spawn_recv_tasks(&self, conn: SunnyQuicConn) {
+        let username = self.config.username.clone();
+        let password = self.config.password.clone();
+
         tokio::spawn(async move {
-            let _ = handle_udp_packet_recv(conn_clone)
+            let _ = auth_sunny(&conn, gen_sunny_user_hash(&username, &password))
+                .await
+                .map_err(|x| error!("authentication failed: {}", x));
+
+            let _ = handle_udp_packet_recv(conn)
                 .await
                 .map_err(|x| error!("handle udp packet recv error: {}", x));
         });
+    }
 
+    async fn connect_with_endpoint(
+        &self,
+        end: &EndClient,
+        addr: SocketAddr,
+    ) -> Result<SunnyQuicConn, SError> {
+        let raw = QuicClient::connect(end, addr, &self.config.server_name).await?;
+        let conn = Self::wrap_conn(raw);
+        self.spawn_recv_tasks(conn.clone());
+        Ok(conn)
+    }
+
+    async fn build_path(&self, addr: SocketAddr) -> Result<(EndClient, SunnyQuicConn), SError> {
+        let end = self.build_endpoint().await?;
+        let conn = self.connect_with_endpoint(&end, addr).await?;
+        Ok((end, conn))
+    }
+
+    fn cleanup_draining(&mut self) {
+        self.draining.retain(|path| {
+            let _keep_endpoint_alive = &path.end;
+
+            if let Some(reason) = QuicConnection::close_reason(&path.conn.conn) {
+                debug!(
+                    "drained quic connection to {} closed due to {}",
+                    path.addr, reason
+                );
+                return false;
+            }
+
+            if path.since.elapsed() >= PORT_HOP_DRAIN_TIMEOUT {
+                debug!(
+                    "closing drained quic connection to {} after {:?}",
+                    path.addr, PORT_HOP_DRAIN_TIMEOUT
+                );
+                path.conn.conn.close(0u8.into(), b"port hop drain timeout");
+                return false;
+            }
+
+            true
+        });
+
+        while self.draining.len() > MAX_DRAINING_PATHS {
+            let old = self.draining.remove(0);
+            debug!(
+                "closing oldest drained quic connection to {} because draining set exceeds {}",
+                old.addr, MAX_DRAINING_PATHS
+            );
+            old.conn
+                .conn
+                .close(0u8.into(), b"port hop draining overflow");
+        }
+    }
+
+    pub async fn get_conn(&self) -> Result<SunnyQuicConn, SError> {
+        self.quic_conn
+            .clone()
+            .ok_or_else(|| std::io::Error::other("quic connection not prepared").into())
+    }
+
+    async fn hop_port(&mut self) -> Result<(), SError> {
+        let addr = self.select_hop_addr();
+        info!("starting soft port hop to server {}", addr);
+
+        // 1. Build new path first. If this fails, the old path remains intact.
+        let (new_end, new_conn) = self.build_path(addr).await?;
+
+        // 2. Move old active path into draining instead of closing it immediately.
+        if let Some(old_conn) = self.quic_conn.take() {
+            if let Some(old_end) = self.quic_end.take() {
+                let old_addr = self
+                    .current_addr
+                    .unwrap_or_else(|| self.resolve_base_addr());
+                debug!("moving old quic path {} into draining set", old_addr);
+
+                self.draining.push(DrainingPath {
+                    end: old_end,
+                    conn: old_conn,
+                    addr: old_addr,
+                    since: Instant::now(),
+                });
+            } else {
+                // Should not normally happen, but if it does, we cannot keep the old path alive safely.
+                warn!(
+                    "active quic connection exists without endpoint; closing old path during hop"
+                );
+                old_conn
+                    .conn
+                    .close(0u8.into(), b"port hop missing endpoint");
+            }
+        }
+
+        // 3. Switch new path to active.
+        self.quic_end = Some(new_end);
         self.quic_conn = Some(new_conn);
+        self.current_addr = Some(addr);
 
-        debug!("port hopped to server port {}", target_port);
+        // 4. Opportunistic cleanup.
+        self.cleanup_draining();
+
+        debug!("soft port hopped to server {}", addr);
+        Ok(())
+    }
+
+    async fn ensure_active_conn(&mut self) -> Result<(), SError> {
+        if self.quic_conn.is_some() {
+            return Ok(());
+        }
+
+        let addr = self
+            .current_addr
+            .unwrap_or_else(|| self.resolve_base_addr());
+
+        if self.quic_end.is_some() {
+            let conn = {
+                let end = self
+                    .quic_end
+                    .as_ref()
+                    .expect("quic_end must exist when quic_end.is_some()");
+                self.connect_with_endpoint(end, addr).await?
+            };
+            self.quic_conn = Some(conn);
+            self.current_addr = Some(addr);
+            return Ok(());
+        }
+
+        let (end, conn) = self.build_path(addr).await?;
+        self.quic_end = Some(end);
+        self.quic_conn = Some(conn);
+        self.current_addr = Some(addr);
         Ok(())
     }
 
     async fn prepare_conn(&mut self) -> Result<(), SError> {
+        // Clean up old drained paths first.
+        self.cleanup_draining();
+
+        // If active connection is already closed, drop only the active connection.
+        // Keep the active endpoint so normal reconnect behavior stays unchanged.
+        let active_closed_reason = self
+            .quic_conn
+            .as_ref()
+            .and_then(|x| QuicConnection::close_reason(&x.conn));
+
+        if let Some(reason) = active_closed_reason {
+            debug!("active quic connection closed due to {}", reason);
+            self.quic_conn = None;
+        }
+
+        // Process pending hop request using make-before-break.
         if self.hop_requested.swap(false, Ordering::SeqCst) {
             match self.hop_port().await {
                 Ok(()) => {}
@@ -232,28 +339,21 @@ impl SunnyQuicClient {
             }
         }
 
-        // delete connection if closed.
-        self.quic_conn.take_if(|x| {
-            QuicConnection::close_reason(&x.conn).is_some_and(|x| {
-                info!("quic connection closed due to {}", x);
-                true
-            })
-        });
-        // Creating new connectin
-        if self.quic_conn.is_none() {
-            self.quic_conn = Some(self.get_conn().await?);
-        }
+        // Ensure there is an active connection.
+        self.ensure_active_conn().await?;
+
         Ok(())
     }
 }
+
 #[async_trait]
 impl Outbound for SunnyQuicClient {
     async fn handle(&mut self, req: crate::ProxyRequest) -> Result<(), crate::error::SError> {
         self.prepare_conn().await?;
 
-        let conn = self.quic_conn.as_mut().unwrap().clone();
-
+        let conn = self.quic_conn.as_ref().unwrap().clone();
         let over_stream = self.config.over_stream;
+
         handle_request(req, conn, over_stream).await?;
         Ok(())
     }

--- a/shadowquic/src/sunnyquic/outbound.rs
+++ b/shadowquic/src/sunnyquic/outbound.rs
@@ -295,14 +295,13 @@ impl SunnyQuicClient {
             .current_addr
             .unwrap_or_else(|| self.resolve_base_addr());
 
-        if self.quic_end.is_some() {
-            let conn = {
-                let end = self
-                    .quic_end
-                    .as_ref()
-                    .expect("quic_end must exist when quic_end.is_some()");
-                self.connect_with_endpoint(end, addr).await?
-            };
+        let conn = if let Some(end) = self.quic_end.as_ref() {
+            Some(self.connect_with_endpoint(end, addr).await?)
+        } else {
+            None
+        };
+
+        if let Some(conn) = conn {
             self.quic_conn = Some(conn);
             self.current_addr = Some(addr);
             return Ok(());

--- a/shadowquic/src/sunnyquic/outbound.rs
+++ b/shadowquic/src/sunnyquic/outbound.rs
@@ -74,9 +74,7 @@ impl SunnyQuicClient {
 
             tokio::spawn(async move {
                 let mark_pending = || {
-                    if !hop_requested_clone.swap(true, Ordering::SeqCst) {
-                        debug!("marking port hop as pending");
-                    }
+                    hop_requested_clone.swap(true, Ordering::SeqCst);
                 };
 
                 mark_pending();
@@ -86,7 +84,7 @@ impl SunnyQuicClient {
                         let mut rng = rand::rng();
                         rng.random_range(MIN_PORT_HOP_INTERVAL..=interval)
                     };
-                    debug!("scheduled port hop request in {} seconds", wait_time);
+                    // debug!("scheduled port hop request in {} seconds", wait_time);
 
                     tokio::select! {
                         _ = tokio::time::sleep(Duration::from_secs(wait_time)) => {
@@ -139,9 +137,7 @@ impl SunnyQuicClient {
             Some(port_hop) => {
                 let mut rng = rand::rng();
                 let (start, end) = (port_hop.range.start, port_hop.range.end);
-                let port = rng.random_range(start..=end);
-                debug!("selected random port {} (range: {}-{})", port, start, end);
-                port
+                rng.random_range(start..=end)
             }
             None => base_port,
         };


### PR DESCRIPTION
Add configurable client-side port hopping for ShadowQuic outbound connections.

Introduce a new `port-hop` client option with a randomized hop interval and configurable server port range. A background timer marks pending hop requests, while `prepare_conn()` performs the actual hop by rebuilding the QUIC endpoint and reconnecting to a newly selected server port.

Additional changes in this commit:
- parse and validate configured port-hop ranges
- reject port 0 in port-hop ranges
- return `DomainResolveFailed` on address resolution failure
- remove panic-based address resolution paths
- simplify hop coordination to a single atomic pending flag
- use a oneshot shutdown signal for the hop timer
- normalize and reduce repeated warning logs for port hopping and GSO