### PR TITLE
add fwmark support for Linux and Android

### DIFF
--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -179,6 +179,10 @@ pub struct ShadowQuicServerCfg {
     /// For stable udp network, it's better to disable it and set a proper initial mtu
     #[serde(default = "default_mtu_discovery")]
     pub mtu_discovery: bool,
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[serde(default)]
+    pub fwmark: Option<u32>,
 }
 
 /// Jls upstream configuration
@@ -214,6 +218,8 @@ impl Default for ShadowQuicServerCfg {
             server_name: None,
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            fwmark: None,
         }
     }
 }
@@ -235,6 +241,8 @@ impl Default for ShadowQuicClientCfg {
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
             cipher_suite_preference: None,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            fwmark: None,
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
         }
@@ -335,6 +343,10 @@ pub struct ShadowQuicClientCfg {
     /// If unset, use rustls/ring default preference order.
     #[serde(default)]
     pub cipher_suite_preference: Option<Vec<CipherSuitePreference>>,
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[serde(default)]
+    pub fwmark: Option<u32>,
 
     /// Android Only. the unix socket path for protecting android socket
     #[cfg(target_os = "android")]

--- a/shadowquic/src/config/sunnyquic.rs
+++ b/shadowquic/src/config/sunnyquic.rs
@@ -75,6 +75,10 @@ pub struct SunnyQuicServerCfg {
     /// Brutal server configuration
     #[serde(default)]
     pub brutal: Option<BrutalParams>,
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[serde(default)]
+    pub fwmark: Option<u32>,
 }
 
 impl Default for SunnyQuicServerCfg {
@@ -94,6 +98,8 @@ impl Default for SunnyQuicServerCfg {
             mtu_discovery: default_mtu_discovery(),
             gso: default_gso(),
             brutal: None,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            fwmark: None,
         }
     }
 }
@@ -118,6 +124,8 @@ impl Default for SunnyQuicClientCfg {
             gso: default_gso(),
             mtu_discovery: default_mtu_discovery(),
             cipher_suite_preference: None,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            fwmark: None,
             #[cfg(target_os = "android")]
             protect_path: Default::default(),
         }
@@ -209,6 +217,10 @@ pub struct SunnyQuicClientCfg {
     /// If unset, use rustls/ring default preference order.
     #[serde(default)]
     pub cipher_suite_preference: Option<Vec<CipherSuitePreference>>,
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[serde(default)]
+    pub fwmark: Option<u32>,
 
     /// Android Only. the unix socket path for protecting android socket
     #[cfg(target_os = "android")]

--- a/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
+++ b/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
@@ -35,6 +35,9 @@ use crate::{
     },
 };
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use crate::utils::dual_socket::{create_marked_udp_socket, try_apply_fwmark};
+
 pub type Connection = quinn::Connection;
 pub struct Endpoint {
     inner: quinn::Endpoint,
@@ -155,6 +158,11 @@ impl QuicClient for Endpoint {
             socket.bind(&bind_addr.into())?;
             socket
         };
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if let Some(mark) = cfg.fwmark {
+            try_apply_fwmark(&socket, mark);
+        }
 
         #[cfg(target_os = "android")]
         if let Some(path) = &cfg.protect_path {
@@ -327,6 +335,37 @@ pub fn gen_client_cfg(cfg: &ShadowQuicClientCfg) -> quinn::ClientConfig {
     config
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn create_quinn_server_endpoint(
+    config: quinn::ServerConfig,
+    bind_addr: std::net::SocketAddr,
+    fwmark: Option<u32>,
+) -> std::io::Result<quinn::Endpoint> {
+    if let Some(mark) = fwmark {
+        let udp_socket = create_marked_udp_socket(bind_addr, mark)?;
+        let runtime = quinn::default_runtime()
+            .ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+        quinn::Endpoint::new(
+            quinn::EndpointConfig::default(),
+            Some(config),
+            udp_socket,
+            runtime,
+        )
+    } else {
+        quinn::Endpoint::server(config, bind_addr)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn create_quinn_server_endpoint(
+    config: quinn::ServerConfig,
+    bind_addr: std::net::SocketAddr,
+    _fwmark: Option<u32>,
+) -> std::io::Result<quinn::Endpoint> {
+    quinn::Endpoint::server(config, bind_addr)
+}
+
 #[async_trait]
 impl QuicServer for Endpoint {
     type C = Connection;
@@ -421,7 +460,13 @@ impl QuicServer for Endpoint {
 
         config.transport_config(Arc::new(tp_cfg));
 
-        let endpoint = quinn::Endpoint::server(config, cfg.bind_addr)?;
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let fwmark = cfg.fwmark;
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        let fwmark = None;
+
+        let endpoint = create_quinn_server_endpoint(config, cfg.bind_addr, fwmark)?;
+
         Ok(Endpoint {
             inner: endpoint,
             zero_rtt: cfg.zero_rtt,

--- a/shadowquic/src/sunnyquic/iroh_wrapper/wrapper.rs
+++ b/shadowquic/src/sunnyquic/iroh_wrapper/wrapper.rs
@@ -41,6 +41,9 @@ use crate::{
     sunnyquic::dynamic_cert::DynamicCertResolver,
 };
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use crate::utils::dual_socket::{create_marked_udp_socket, try_apply_fwmark};
+
 pub type Connection = iroh_quinn::Connection;
 pub struct Endpoint<SC> {
     inner: iroh_quinn::Endpoint,
@@ -161,6 +164,12 @@ impl QuicClient for Endpoint<SunnyQuicClientCfg> {
             socket.bind(&bind_addr.into())?;
             socket
         };
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if let Some(mark) = cfg.fwmark {
+            try_apply_fwmark(&socket, mark);
+        }
+
         #[cfg(target_os = "android")]
         if let Some(path) = &cfg.protect_path {
             use crate::utils::protect_socket::protect_socket_with_retry;
@@ -391,6 +400,37 @@ pub fn gen_client_cfg(cfg: &SunnyQuicClientCfg) -> iroh_quinn::ClientConfig {
     config
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn create_iroh_server_endpoint(
+    config: iroh_quinn::ServerConfig,
+    bind_addr: std::net::SocketAddr,
+    fwmark: Option<u32>,
+) -> std::io::Result<iroh_quinn::Endpoint> {
+    if let Some(mark) = fwmark {
+        let udp_socket = create_marked_udp_socket(bind_addr, mark)?;
+        let runtime = iroh_quinn::default_runtime()
+            .ok_or_else(|| std::io::Error::other("no async runtime found"))?;
+
+        iroh_quinn::Endpoint::new(
+            iroh_quinn::EndpointConfig::default(),
+            Some(config),
+            udp_socket,
+            runtime,
+        )
+    } else {
+        iroh_quinn::Endpoint::server(config, bind_addr)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn create_iroh_server_endpoint(
+    config: iroh_quinn::ServerConfig,
+    bind_addr: std::net::SocketAddr,
+    _fwmark: Option<u32>,
+) -> std::io::Result<iroh_quinn::Endpoint> {
+    iroh_quinn::Endpoint::server(config, bind_addr)
+}
+
 #[async_trait]
 impl QuicServer for Endpoint<SunnyQuicServerCfg> {
     type C = Connection;
@@ -474,7 +514,13 @@ impl QuicServer for Endpoint<SunnyQuicServerCfg> {
 
         config.transport_config(Arc::new(tp_cfg));
 
-        let endpoint = iroh_quinn::Endpoint::server(config, cfg.bind_addr)?;
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let fwmark = cfg.fwmark;
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        let fwmark = None;
+
+        let endpoint = create_iroh_server_endpoint(config, cfg.bind_addr, fwmark)?;
+
         Ok(Endpoint {
             inner: endpoint,
             cfg: Arc::new(cfg.to_owned()),

--- a/shadowquic/src/utils/dual_socket.rs
+++ b/shadowquic/src/utils/dual_socket.rs
@@ -81,3 +81,36 @@ pub fn to_ipv4_mapped(mut addr: SocketAddr) -> SocketAddr {
     addr.set_ip(ip);
     addr
 }
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn try_apply_fwmark(socket: &Socket, mark: u32) {
+    tracing::info!("setting socket fwmark to {}", mark);
+    socket.set_mark(mark).unwrap_or_else(|e| {
+        tracing::warn!(
+            "failed to set fwmark {} on socket: {}. \
+                the socket will continue without fwmark; \
+                ensure CAP_NET_ADMIN capability is granted if fwmark is required.",
+            mark,
+            e
+        );
+    });
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn create_marked_udp_socket(
+    addr: SocketAddr,
+    mark: u32,
+) -> std::io::Result<std::net::UdpSocket> {
+    let domain = match addr {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+    try_apply_fwmark(&socket, mark);
+    socket.bind(&addr.into())?;
+
+    Ok(socket.into())
+}


### PR DESCRIPTION
Allow configuring a firewall mark (SO_MARK) on QUIC UDP sockets for traffic routing and netfilter/iptables policy integration.

- Add fwmark field to ShadowQuic and SunnyQuic client/server configs
- Apply fwmark on client sockets after creation
- Create pre-marked UDP sockets for server endpoints (quinn/iroh)
- Add platform-gated helpers: try_apply_fwmark, create_marked_udp_socket