### PR TITLE
Mixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3091,6 +3091,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "aws-lc-rs",
+ "base64 0.22.1",
  "brutal-core",
  "bytes",
  "clap",

--- a/shadowquic/Cargo.toml
+++ b/shadowquic/Cargo.toml
@@ -81,6 +81,7 @@ console-subscriber = { version = "0.5.0", optional = true }
 serde-saphyr = "0.0.26"
 aws-lc-rs = { version = "1", optional = true, default-features = false }
 ring = { version = "0.17.14", optional = true }
+base64 = "0.22.1"
 
 [target.'cfg(target_os="android")'.dependencies]
 sendfd = { version = "0.4.4", features = ["tokio"] }

--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     Inbound, Manager, Outbound,
     direct::outbound::DirectOut,
     error::SError,
+    mixed::inbound::MixedServer,
     shadowquic::{inbound::ShadowQuicServer, outbound::ShadowQuicClient},
     socks::{inbound::SocksServer, outbound::SocksClient},
     sunnyquic::{inbound::SunnyQuicServer, outbound::SunnyQuicClient},
@@ -63,6 +64,7 @@ impl Config {
 #[serde(tag = "type")]
 pub enum InboundCfg {
     Socks(SocksServerCfg),
+    Mixed(MixedServerCfg),
     #[serde(rename = "shadowquic")]
     ShadowQuic(ShadowQuicServerCfg),
     #[serde(rename = "sunnyquic")]
@@ -72,6 +74,7 @@ impl InboundCfg {
     async fn build_inbound(self) -> Result<Box<dyn Inbound>, SError> {
         let r: Box<dyn Inbound> = match self {
             InboundCfg::Socks(cfg) => Box::new(SocksServer::new(cfg).await?),
+            InboundCfg::Mixed(cfg) => Box::new(MixedServer::new(cfg).await?),
             InboundCfg::ShadowQuic(cfg) => Box::new(ShadowQuicServer::new(cfg)?),
             InboundCfg::SunnyQuic(cfg) => Box::new(SunnyQuicServer::new(cfg)?),
         };
@@ -124,6 +127,26 @@ impl OutboundCfg {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct SocksServerCfg {
     /// Server binding address. e.g. `0.0.0.0:1089`, `[::1]:1089`
+    pub bind_addr: SocketAddr,
+    /// Socks5 username, optional
+    /// Left empty to disable authentication
+    #[serde(default = "Vec::new")]
+    pub users: Vec<AuthUser>,
+}
+
+/// Mixed inbound configuration
+///
+/// Supports SOCKS5 and HTTP proxy (CONNECT + plain HTTP forwarding) on the same port.
+///
+/// Example:
+/// ```yaml
+/// type: mixed
+/// bind-addr: "0.0.0.0:1080"
+/// ```
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct MixedServerCfg {
+    /// Server binding address. e.g. `0.0.0.0:1080`, `[::]:1080`
     pub bind_addr: SocketAddr,
     /// Socks5 username, optional
     /// Left empty to disable authentication

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -132,6 +132,7 @@ impl Default for ShadowQuicClientCfg {
             cipher_suite_preference: None,
             socket_opt: Default::default(),
             protect_path: Default::default(),
+            stats: StatsConfig::default(),
         }
     }
 }
@@ -159,6 +160,13 @@ impl Default for BrutalParams {
             ack_compensate: default_brutal_ack_compensate(),
         }
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct StatsConfig {
+    pub socket_path: Option<std::path::PathBuf>,
+    pub upstream_id: Option<String>,
 }
 
 /// Shadowquic outbound configuration
@@ -238,6 +246,10 @@ pub struct ShadowQuicClientCfg {
     /// Socket options like bind interface and fwmark
     #[serde(flatten)]
     pub socket_opt: SocketOpt,
+
+    /// Stats push to xtp-rs Unix DGRAM socket.
+    #[serde(default)]
+    pub stats: StatsConfig,
 }
 
 impl HasCipherSuitePreference for ShadowQuicClientCfg {

--- a/shadowquic/src/direct/outbound.rs
+++ b/shadowquic/src/direct/outbound.rs
@@ -6,6 +6,7 @@ use std::{
 
 use bytes::BytesMut;
 use tokio::{
+    io::AsyncWriteExt,
     net::{TcpStream, lookup_host},
     sync::Mutex,
 };
@@ -33,6 +34,7 @@ impl Outbound for DirectOut {
     ) -> anyhow::Result<(), crate::error::SError> {
         let dns_strategy = self.cfg.dns_strategy.clone();
         let self_clone = self.clone();
+
         let fut = async move {
             match req {
                 crate::ProxyRequest::Tcp(mut tcp_session) => {
@@ -41,6 +43,7 @@ impl Outbound for DirectOut {
                     let dst = apply_dns_strategy(dst, &dns_strategy)
                         .ok_or(SError::DomainResolveFailed(tcp_session.dst.to_string()))?;
                     trace!("resolved to {}", dst);
+
                     let mut upstream = TcpStream::connect(dst).await?;
                     let (_, _) = tokio::io::copy_bidirectional_with_sizes(
                         &mut tcp_session.stream,
@@ -50,12 +53,35 @@ impl Outbound for DirectOut {
                     )
                     .await?;
                 }
+
+                crate::ProxyRequest::Http(mut http_session) => {
+                    trace!("direct http forward to {}", http_session.dst);
+                    let dst = http_session.dst.to_socket_addrs()?;
+                    let dst = apply_dns_strategy(dst, &dns_strategy)
+                        .ok_or(SError::DomainResolveFailed(http_session.dst.to_string()))?;
+                    trace!("resolved to {}", dst);
+
+                    let mut upstream = TcpStream::connect(dst).await?;
+                    upstream.write_all(&http_session.first_packet).await?;
+                    upstream.flush().await?;
+
+                    let (_, _) = tokio::io::copy_bidirectional_with_sizes(
+                        &mut http_session.stream,
+                        &mut upstream,
+                        1024 * 16,
+                        1024 * 16,
+                    )
+                    .await?;
+                }
+
                 crate::ProxyRequest::Udp(udp_session) => {
                     self_clone.handle_udp(udp_session).await?;
                 }
             }
+
             Ok(()) as Result<(), SError>
         };
+
         let span = trace_span!("direct");
         tokio::spawn(
             async {

--- a/shadowquic/src/http/inbound.rs
+++ b/shadowquic/src/http/inbound.rs
@@ -1,0 +1,358 @@
+use std::str;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::{
+    HttpForwardSession, ProxyRequest, TcpSession, TcpTrait,
+    error::SError,
+    msgs::socks5::{AddrOrDomain, SocksAddr},
+    utils::replay_stream::ReplayStream,
+};
+
+#[derive(Clone, Debug)]
+pub struct ProxyBasicAuth {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Default)]
+pub struct HttpProxyServer {
+    users: Vec<ProxyBasicAuth>,
+}
+
+impl HttpProxyServer {
+    pub fn new() -> Self {
+        Self { users: Vec::new() }
+    }
+
+    pub fn with_users(users: Vec<ProxyBasicAuth>) -> Self {
+        Self { users }
+    }
+
+    pub fn auth_enabled(&self) -> bool {
+        !self.users.is_empty()
+    }
+
+    pub async fn accept_stream<S>(&self, mut stream: S) -> Result<ProxyRequest, SError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static + TcpTrait,
+    {
+        let (header, remain) = Self::read_header(&mut stream).await?;
+        let text = str::from_utf8(&header)
+            .map_err(|_| SError::SocksError("invalid http request".into()))?;
+
+        let mut lines = text.split("\r\n");
+        let request_line = lines
+            .next()
+            .ok_or_else(|| SError::SocksError("empty http request".into()))?;
+
+        let line = request_line.trim();
+        let mut parts = line.split_whitespace();
+        let method = parts.next().unwrap_or_default();
+        let target = parts.next().unwrap_or_default();
+        let version = parts.next().unwrap_or_default();
+
+        if method.is_empty() || target.is_empty() || version.is_empty() {
+            return Err(SError::SocksError("invalid http request line".into()));
+        }
+
+        if self.auth_enabled() && !check_proxy_basic_auth(text, &self.users) {
+            write_proxy_auth_required(&mut stream).await?;
+            return Err(SError::SocksError("http proxy auth failed".into()));
+        }
+
+        if method.eq_ignore_ascii_case("CONNECT") {
+            let dst = parse_connect_target(target)?;
+
+            stream
+                .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                .await?;
+            stream.flush().await?;
+
+            let stream = ReplayStream::new(remain, stream);
+
+            return Ok(ProxyRequest::Tcp(TcpSession {
+                stream: Box::new(stream),
+                dst,
+            }));
+        }
+
+        let (dst, rewritten_header) = rewrite_forward_request(&header)?;
+        let mut first_packet = rewritten_header;
+        first_packet.extend_from_slice(&remain);
+
+        Ok(ProxyRequest::Http(HttpForwardSession {
+            stream: Box::new(stream),
+            dst,
+            first_packet,
+        }))
+    }
+
+    async fn read_header<S>(stream: &mut S) -> Result<(Vec<u8>, Vec<u8>), SError>
+    where
+        S: AsyncRead + Unpin,
+    {
+        const MAX_HEADER: usize = 32 * 1024;
+        let mut buf = Vec::with_capacity(1024);
+        let mut tmp = [0u8; 1024];
+
+        loop {
+            let n = stream.read(&mut tmp).await?;
+            if n == 0 {
+                return Err(SError::SocksError(
+                    "connection closed before http header completed".into(),
+                ));
+            }
+
+            buf.extend_from_slice(&tmp[..n]);
+
+            if let Some(end) = find_header_end(&buf) {
+                let header = buf[..end].to_vec();
+                let remain = buf[end..].to_vec();
+                return Ok((header, remain));
+            }
+
+            if buf.len() > MAX_HEADER {
+                return Err(SError::SocksError("http header too large".into()));
+            }
+        }
+    }
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|pos| pos + 4)
+}
+
+fn check_proxy_basic_auth(text: &str, users: &[ProxyBasicAuth]) -> bool {
+    let Some(value) = find_header_value(text, "Proxy-Authorization") else {
+        return false;
+    };
+
+    let Some(encoded) = value.strip_prefix("Basic ") else {
+        return false;
+    };
+
+    let Ok(decoded) = STANDARD.decode(encoded.trim()) else {
+        return false;
+    };
+
+    let Ok(decoded) = str::from_utf8(&decoded) else {
+        return false;
+    };
+
+    users
+        .iter()
+        .any(|u| decoded == format!("{}:{}", u.username, u.password))
+}
+
+fn find_header_value<'a>(text: &'a str, name: &str) -> Option<&'a str> {
+    for line in text.split("\r\n").skip(1) {
+        if line.is_empty() {
+            break;
+        }
+
+        let line = line.trim();
+        let Some((k, v)) = line.split_once(':') else {
+            continue;
+        };
+
+        if k.trim().eq_ignore_ascii_case(name) {
+            return Some(v.trim());
+        }
+    }
+
+    None
+}
+
+async fn write_proxy_auth_required<S>(stream: &mut S) -> Result<(), SError>
+where
+    S: AsyncWrite + Unpin,
+{
+    let resp = concat!(
+        "HTTP/1.1 407 Proxy Authentication Required\r\n",
+        "Proxy-Authenticate: Basic realm=\"shadowquic\"\r\n",
+        "Content-Length: 0\r\n",
+        "Connection: close\r\n",
+        "\r\n"
+    );
+
+    stream.write_all(resp.as_bytes()).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+fn parse_connect_target(target: &str) -> Result<SocksAddr, SError> {
+    let target = target.trim();
+    let (host, port_str) = if let Some(rest) = target.strip_prefix('[') {
+        let end = rest
+            .find(']')
+            .ok_or_else(|| SError::SocksError("invalid connect target".into()))?;
+        let host = &rest[..end];
+        let remain = &rest[end + 1..];
+        let port = remain
+            .strip_prefix(':')
+            .ok_or_else(|| SError::SocksError("missing port".into()))?;
+        (host, port)
+    } else {
+        let idx = target
+            .rfind(':')
+            .ok_or_else(|| SError::SocksError("missing port".into()))?;
+        (&target[..idx], &target[idx + 1..])
+    };
+
+    let port: u16 = port_str
+        .parse()
+        .map_err(|_| SError::SocksError("invalid port".into()))?;
+
+    make_socks_addr(host, port)
+}
+
+fn rewrite_forward_request(header: &[u8]) -> Result<(SocksAddr, Vec<u8>), SError> {
+    let text =
+        str::from_utf8(header).map_err(|_| SError::SocksError("invalid http request".into()))?;
+    let text = text.trim_start();
+    let mut lines = text.split("\r\n");
+
+    let request_line = lines
+        .next()
+        .ok_or_else(|| SError::SocksError("empty http request".into()))?;
+
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    let version = parts.next().unwrap_or_default();
+
+    if method.is_empty() || target.is_empty() || version.is_empty() {
+        return Err(SError::SocksError("invalid http request line".into()));
+    }
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        return Err(SError::SocksError("unexpected connect request".into()));
+    }
+
+    let parsed = parse_absolute_http_uri(target)?;
+    let dst = make_socks_addr(&parsed.host, parsed.port)?;
+
+    let mut out = Vec::with_capacity(header.len() + 64);
+    out.extend_from_slice(format!("{method} {} {version}\r\n", parsed.path_and_query).as_bytes());
+
+    let host_header = if parsed.port == 80 {
+        parsed.host.clone()
+    } else if parsed.host.contains(':') {
+        format!("[{}]:{}", parsed.host, parsed.port)
+    } else {
+        format!("{}:{}", parsed.host, parsed.port)
+    };
+
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+
+        let lower = line.to_ascii_lowercase();
+
+        if lower.starts_with("host:") {
+            continue;
+        }
+        if lower.starts_with("proxy-connection:") {
+            continue;
+        }
+        if lower.starts_with("connection:") {
+            continue;
+        }
+        if lower.starts_with("keep-alive:") {
+            continue;
+        }
+        if lower.starts_with("proxy-authenticate:") {
+            continue;
+        }
+        if lower.starts_with("proxy-authorization:") {
+            continue;
+        }
+
+        out.extend_from_slice(line.as_bytes());
+        out.extend_from_slice(b"\r\n");
+    }
+
+    out.extend_from_slice(format!("Host: {host_header}\r\n").as_bytes());
+    out.extend_from_slice(b"Connection: close\r\n");
+    out.extend_from_slice(b"\r\n");
+
+    Ok((dst, out))
+}
+
+struct ParsedHttpUri {
+    host: String,
+    port: u16,
+    path_and_query: String,
+}
+
+fn parse_absolute_http_uri(target: &str) -> Result<ParsedHttpUri, SError> {
+    let rest = target
+        .strip_prefix("http://")
+        .ok_or_else(|| SError::SocksError("only absolute http:// URI is supported".into()))?;
+
+    let (authority, path_and_query) = match rest.find('/') {
+        Some(idx) => (&rest[..idx], &rest[idx..]),
+        None => (rest, "/"),
+    };
+
+    if authority.is_empty() {
+        return Err(SError::SocksError("missing authority".into()));
+    }
+
+    let (host, port) = if let Some(rest) = authority.strip_prefix('[') {
+        let end = rest
+            .find(']')
+            .ok_or_else(|| SError::SocksError("invalid ipv6 authority".into()))?;
+        let host = &rest[..end];
+        let remain = &rest[end + 1..];
+        let port = if remain.is_empty() {
+            80
+        } else {
+            let p = remain
+                .strip_prefix(':')
+                .ok_or_else(|| SError::SocksError("invalid ipv6 authority".into()))?;
+            p.parse()
+                .map_err(|_| SError::SocksError("invalid port".into()))?
+        };
+        (host.to_string(), port)
+    } else {
+        match authority.rfind(':') {
+            Some(idx) if authority[idx + 1..].chars().all(|c| c.is_ascii_digit()) => {
+                let host = &authority[..idx];
+                let port: u16 = authority[idx + 1..]
+                    .parse()
+                    .map_err(|_| SError::SocksError("invalid port".into()))?;
+                (host.to_string(), port)
+            }
+            _ => (authority.to_string(), 80),
+        }
+    };
+
+    if host.is_empty() {
+        return Err(SError::SocksError("missing host".into()));
+    }
+
+    Ok(ParsedHttpUri {
+        host,
+        port,
+        path_and_query: path_and_query.to_string(),
+    })
+}
+
+fn make_socks_addr(host: &str, port: u16) -> Result<SocksAddr, SError> {
+    let addr = if let Ok(v4) = host.parse::<std::net::Ipv4Addr>() {
+        AddrOrDomain::V4(v4.octets())
+    } else if let Ok(v6) = host.parse::<std::net::Ipv6Addr>() {
+        AddrOrDomain::V6(v6.octets())
+    } else {
+        AddrOrDomain::Domain(host.as_bytes().to_vec().into())
+    };
+
+    Ok(SocksAddr { addr, port })
+}

--- a/shadowquic/src/http/mod.rs
+++ b/shadowquic/src/http/mod.rs
@@ -1,0 +1,1 @@
+pub mod inbound;

--- a/shadowquic/src/lib.rs
+++ b/shadowquic/src/lib.rs
@@ -14,6 +14,8 @@ use tracing::error;
 pub mod config;
 pub mod direct;
 pub mod error;
+pub mod http;
+pub mod mixed;
 pub mod msgs;
 pub mod quic;
 pub mod shadowquic;
@@ -27,6 +29,7 @@ pub use msgs::SEncode;
 pub enum ProxyRequest<T = AnyTcp, I = AnyUdpRecv, O = AnyUdpSend> {
     Tcp(TcpSession<T>),
     Udp(UdpSession<I, O>),
+    Http(HttpForwardSession),
 }
 /// Udp socket only use immutable reference to self
 /// So it can be safely wrapped by Arc and cloned to work in duplex way.
@@ -49,6 +52,12 @@ pub struct UdpSession<I = AnyUdpRecv, O = AnyUdpSend> {
     /// Control stream, should be kept alive during session.
     stream: Option<AnyTcp>,
     bind_addr: SocksAddr,
+}
+
+pub struct HttpForwardSession {
+    pub stream: Box<dyn TcpTrait>,
+    pub dst: SocksAddr,
+    pub first_packet: Vec<u8>,
 }
 
 pub type AnyTcp = Box<dyn TcpTrait>;

--- a/shadowquic/src/mixed/inbound.rs
+++ b/shadowquic/src/mixed/inbound.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use socket2::{Domain, Protocol, Socket, Type};
+use tokio::{io::AsyncReadExt, net::TcpListener};
+
+use crate::{
+    Inbound, ProxyRequest,
+    config::AuthUser,
+    config::MixedServerCfg,
+    error::SError,
+    http::inbound::{HttpProxyServer, ProxyBasicAuth},
+    socks::inbound::SocksServer,
+    utils::dual_socket::to_ipv4_mapped,
+    utils::replay_stream::ReplayStream,
+};
+
+pub struct MixedServer {
+    listener: TcpListener,
+    http: HttpProxyServer,
+    users: Vec<AuthUser>,
+}
+
+impl MixedServer {
+    pub async fn new(cfg: MixedServerCfg) -> Result<Self, SError> {
+        let MixedServerCfg { bind_addr, users } = cfg;
+
+        let dual_stack = bind_addr.is_ipv6();
+        let socket = Socket::new(
+            if dual_stack {
+                Domain::IPV6
+            } else {
+                Domain::IPV4
+            },
+            Type::STREAM,
+            Some(Protocol::TCP),
+        )?;
+        if dual_stack {
+            let _ = socket
+                .set_only_v6(false)
+                .map_err(|e| tracing::warn!("failed to set dual stack for socket: {}", e));
+        }
+        socket.set_reuse_address(true)?;
+        socket.set_nonblocking(true)?;
+        socket.bind(&bind_addr.into())?;
+        socket.listen(256)?;
+
+        let listener = TcpListener::from_std(socket.into())
+            .map_err(|e| SError::SocksError(format!("failed to create TcpListener: {e}")))?;
+
+        let http_users = users
+            .iter()
+            .map(|u| ProxyBasicAuth {
+                username: u.username.clone(),
+                password: u.password.clone(),
+            })
+            .collect();
+
+        Ok(Self {
+            listener,
+            http: HttpProxyServer::with_users(http_users),
+            users,
+        })
+    }
+}
+
+#[async_trait]
+impl Inbound for MixedServer {
+    async fn accept(&mut self) -> Result<ProxyRequest, SError> {
+        let (mut stream, _addr) = self.listener.accept().await?;
+        let local_addr = to_ipv4_mapped(stream.local_addr().unwrap());
+
+        // 只读一个字节，客户端没发数据就自然卡住（和 socks5 一样）
+        let first_byte = stream.read_u8().await?;
+
+        if first_byte == 0x05 {
+            let prefix = vec![first_byte];
+            return SocksServer::accept_stream_with_local_addr(
+                ReplayStream::new(prefix, stream),
+                local_addr,
+                &self.users,
+            )
+            .await;
+        }
+
+        // 否则当 HTTP 处理，把第一个字节也塞回去，让 HTTP 解析器自己慢慢读
+        let prefix = vec![first_byte];
+        self.http
+            .accept_stream(ReplayStream::new(prefix, stream))
+            .await
+    }
+}

--- a/shadowquic/src/mixed/mod.rs
+++ b/shadowquic/src/mixed/mod.rs
@@ -1,0 +1,1 @@
+pub mod inbound;

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -14,6 +14,7 @@ use crate::{
     utils::socket_opt::{SocketFactory, UdpSocketFactory},
 };
 
+use crate::quic::QuicConnection;
 use crate::squic::{IDStore, SQConn, handle_udp_packet_recv};
 
 pub type ShadowQuicConn = SQConn<<EndClient as QuicClient>::C>;

--- a/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
+++ b/shadowquic/src/shadowquic/quinn_wrapper/wrapper.rs
@@ -1,3 +1,4 @@
+use std::os::unix::net::UnixDatagram;
 use std::{io, net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 
 use super::brutal::BrutalConfig;
@@ -25,7 +26,7 @@ use quinn::rustls::crypto::ring as crypto_provider;
 use crate::{
     config::{
         CipherSuitePreference, CongestionControl, ShadowQuicClientCfg, ShadowQuicServerCfg,
-        maybe_warn_cipher_suite_on_weak_arch, normalize_cipher_suite_preference,
+        StatsConfig, maybe_warn_cipher_suite_on_weak_arch, normalize_cipher_suite_preference,
     },
     error::SResult,
     msgs::squic::ConnStats,
@@ -36,10 +37,64 @@ use crate::{
     utils::socket_opt::{SocketFactory, UdpSocketFactory},
 };
 
-pub type Connection = quinn::Connection;
+pub struct StatsReporter {
+    sock: Option<Arc<UnixDatagram>>,
+    path: Option<std::path::PathBuf>,
+    upstream_id: String,
+    peer: String,
+}
+
+impl Clone for StatsReporter {
+    fn clone(&self) -> Self {
+        Self {
+            sock: self.sock.clone(),
+            path: self.path.clone(),
+            upstream_id: self.upstream_id.clone(),
+            peer: self.peer.clone(),
+        }
+    }
+}
+
+impl StatsReporter {
+    pub fn new(cfg: Option<&StatsConfig>, peer: String) -> Self {
+        let (path, upstream_id) = match cfg {
+            Some(c) => (c.socket_path.clone(), c.upstream_id.clone()),
+            None => (None, None),
+        };
+        let sock = path
+            .as_ref()
+            .and_then(|_| UnixDatagram::unbound().ok().map(Arc::new));
+        Self {
+            sock,
+            path,
+            upstream_id: upstream_id.unwrap_or_else(|| peer.clone()),
+            peer,
+        }
+    }
+
+    pub fn report(&self, rtt_ms: f64, loss_rate: f64, mtu: u16) {
+        let (Some(sock), Some(path)) = (&self.sock, &self.path) else {
+            return;
+        };
+        let payload = format!(
+            r#"{{"upstream_id":"{}","peer":"{}","rtt_ms":{:.3},"loss_rate":{:.4},"mtu":{}}}
+"#,
+            self.upstream_id, self.peer, rtt_ms, loss_rate, mtu
+        );
+        let _ = sock.send_to(payload.as_bytes(), path);
+    }
+}
+
+#[derive(Clone)]
+pub struct Connection {
+    inner: quinn::Connection,
+    reporter: StatsReporter,
+}
+
 pub struct Endpoint {
     inner: quinn::Endpoint,
     zero_rtt: bool,
+    stats_config: Option<StatsConfig>,
 }
 impl Deref for Endpoint {
     type Target = quinn::Endpoint;
@@ -56,22 +111,34 @@ impl QuicConnection for Connection {
     type RecvStream = quinn::RecvStream;
     type SendStream = quinn::SendStream;
     async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream, u64), QuicErrorRepr> {
-        let (send, recv) = self.open_bi().await?;
-
+        let rate: f32 = (self.inner.stats().path.lost_packets as f32)
+            / ((self.inner.stats().path.sent_packets + 1) as f32);
+        let rtt_ms = self.inner.rtt().as_secs_f64() * 1000.0;
+        let mtu = self.inner.stats().path.current_mtu;
+        self.reporter.report(rtt_ms, rate as f64, mtu);
+        info!(
+            "packet_loss_rate:{:.2}%, rtt:{:.3}ms, mtu:{}",
+            rate * 100.0,
+            rtt_ms,
+            mtu,
+        );
+        let (send, recv) = self.inner.open_bi().await?;
         let id = send.id().index();
         Ok((send, recv, id))
     }
 
     async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream, u64), QuicErrorRepr> {
-        let (send, recv) = self.accept_bi().await?;
-
-        let rate: f32 =
-            (self.stats().path.lost_packets as f32) / ((self.stats().path.sent_packets + 1) as f32);
+        let (send, recv) = self.inner.accept_bi().await?;
+        let rate: f32 = (self.inner.stats().path.lost_packets as f32)
+            / ((self.inner.stats().path.sent_packets + 1) as f32);
+        let rtt_ms = self.inner.rtt().as_secs_f64() * 1000.0;
+        let mtu = self.inner.stats().path.current_mtu;
+        self.reporter.report(rtt_ms, rate as f64, mtu);
         info!(
-            "packet_loss_rate:{:.2}%, rtt:{:?}, mtu:{}",
+            "packet_loss_rate:{:.2}%, rtt:{:.3}ms, mtu:{}",
             rate * 100.0,
-            self.rtt(),
-            self.stats().path.current_mtu,
+            rtt_ms,
+            mtu,
         );
 
         let id = send.id().index();
@@ -79,30 +146,30 @@ impl QuicConnection for Connection {
     }
 
     async fn open_uni(&self) -> Result<(Self::SendStream, u64), QuicErrorRepr> {
-        let send = self.open_uni().await?;
+        let send = self.inner.open_uni().await?;
         let id = send.id().index();
         Ok((send, id))
     }
 
     async fn accept_uni(&self) -> Result<(Self::RecvStream, u64), QuicErrorRepr> {
-        let recv = self.accept_uni().await?;
+        let recv = self.inner.accept_uni().await?;
         let id = recv.id().index();
         Ok((recv, id))
     }
 
     async fn read_datagram(&self) -> Result<Bytes, QuicErrorRepr> {
-        let bytes = self.read_datagram().await?;
+        let bytes = self.inner.read_datagram().await?;
         Ok(bytes)
     }
 
     async fn send_datagram(&self, bytes: Bytes) -> Result<(), QuicErrorRepr> {
         let len = bytes.len();
-        match self.send_datagram(bytes) {
+        match self.inner.send_datagram(bytes) {
             Ok(_) => (),
             Err(SendDatagramError::TooLarge) => warn!(
                 "datagram too large:{}>{}",
                 len,
-                self.max_datagram_size().unwrap()
+                self.inner.max_datagram_size().unwrap()
             ),
             e => e?,
         }
@@ -110,23 +177,24 @@ impl QuicConnection for Connection {
     }
 
     fn close_reason(&self) -> Option<QuicErrorRepr> {
-        self.close_reason().map(|x| x.into())
+        self.inner.close_reason().map(|x| x.into())
     }
     fn remote_address(&self) -> SocketAddr {
-        self.remote_address()
+        self.inner.remote_address()
     }
     fn peer_id(&self) -> u64 {
-        self.stable_id() as u64
+        self.inner.stable_id() as u64
     }
     fn close(&self, error_code: u64, reason: &[u8]) {
-        self.close(VarInt::from_u64(error_code).unwrap(), reason);
+        self.inner
+            .close(VarInt::from_u64(error_code).unwrap(), reason);
     }
     fn get_conn_stats(&self) -> Option<ConnStats> {
-        let stats = self.stats();
+        let stats = self.inner.stats();
         Some(ConnStats {
             lost_packets: stats.path.lost_packets,
             sent_packets: stats.path.sent_packets,
-            rtt: self.rtt().as_secs_f64() * 1000.0,
+            rtt: self.inner.rtt().as_secs_f64() * 1000.0,
             current_mtu: stats.path.current_mtu,
         })
     }
@@ -180,7 +248,13 @@ impl QuicClient for Endpoint {
             conn.close(0u8.into(), b"");
             return Err(QuicErrorRepr::JlsAuthFailed);
         }
-        Ok(conn)
+
+        let peer = conn.remote_address().to_string();
+        let reporter = StatsReporter::new(self.stats_config.as_ref(), peer);
+        Ok(Connection {
+            inner: conn,
+            reporter,
+        })
     }
 
     async fn new_with_socket_factory(
@@ -199,6 +273,7 @@ impl QuicClient for Endpoint {
         Ok(Endpoint {
             inner: end,
             zero_rtt: cfg.zero_rtt,
+            stats_config: Some(cfg.stats.clone()),
         })
     }
 
@@ -403,6 +478,7 @@ impl QuicServer for Endpoint {
         Ok(Endpoint {
             inner: endpoint,
             zero_rtt: cfg.zero_rtt,
+            stats_config: None,
         })
     }
     async fn accept(&self) -> Result<Self::C, QuicErrorRepr> {
@@ -432,7 +508,12 @@ impl QuicServer for Endpoint {
                     connection.close(0u8.into(), b"");
                     return Err(QuicErrorRepr::JlsAuthFailed);
                 }
-                Ok(connection)
+                let peer = connection.remote_address().to_string();
+                let reporter = StatsReporter::new(self.stats_config.as_ref(), peer);
+                Ok(Connection {
+                    inner: connection,
+                    reporter,
+                })
             }
             None => {
                 panic!("Quic endpoint closed");

--- a/shadowquic/src/socks/inbound.rs
+++ b/shadowquic/src/socks/inbound.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use crate::TcpTrait;
 use crate::config::{AuthUser, SocksServerCfg};
 use crate::error::SError;
 use crate::msgs::socks5::{
@@ -13,12 +14,13 @@ use crate::utils::dual_socket::to_ipv4_mapped;
 use crate::{Inbound, ProxyRequest, TcpSession, UdpSession};
 use async_trait::async_trait;
 use socket2::{Domain, Protocol, Socket, Type};
-use tokio::net::{TcpListener, TcpStream, UdpSocket};
+use tokio::net::{TcpListener, UdpSocket};
 
 use anyhow::Result;
 use tracing::{Instrument, info, info_span};
 
 use super::UdpSocksWrap;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pub struct SocksServer {
     #[allow(dead_code)]
@@ -56,23 +58,35 @@ impl SocksServer {
             users: cfg.users,
         })
     }
-    pub async fn authenticate(&self, mut stream: TcpStream) -> Result<TcpStream, SError> {
+
+    async fn authenticate<S>(mut stream: S, users: &[AuthUser]) -> Result<S, SError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send,
+    {
         let auth_req = AuthReq::decode(&mut stream).await?;
         if auth_req.version != SOCKS5_VERSION {
             return Err(SError::ProtocolViolation);
         }
+
         let methods = auth_req.methods;
         if methods.contents.is_empty() {
             return Err(SError::ProtocolViolation);
         }
-        let method = if self.users.is_empty() {
+
+        let method = if users.is_empty() {
             SOCKS5_AUTH_METHOD_NONE
         } else {
             SOCKS5_AUTH_METHOD_PASSWORD
         };
+
         if !methods.contents.contains(&method) {
+            let reply = socks5::AuthReply {
+                version: SOCKS5_VERSION,
+                method: 0xFF,
+            };
+            reply.encode(&mut stream).await?;
             return Err(SError::SocksError(format!(
-                "authentication method not supported:{:?}",
+                "authentication method not supported: {:?}",
                 methods.contents
             )));
         }
@@ -82,31 +96,49 @@ impl SocksServer {
             method,
         };
         reply.encode(&mut stream).await?;
-        if self.users.is_empty() {
+
+        if users.is_empty() {
             return Ok(stream);
         }
+
         let auth = PasswordAuthReq::decode(&mut stream).await?;
-        if !self.users.contains(&AuthUser {
-            username: String::from_utf8(auth.username.contents)
-                .map_err(|_| SError::SocksError("invalid UTF-8 in username".to_string()))?,
-            password: String::from_utf8(auth.password.contents)
-                .map_err(|_| SError::SocksError("invalid UTF-8 in password".to_string()))?,
-        }) {
+
+        let username = String::from_utf8(auth.username.contents)
+            .map_err(|_| SError::SocksError("invalid UTF-8 in username".to_string()))?;
+        let password = String::from_utf8(auth.password.contents)
+            .map_err(|_| SError::SocksError("invalid UTF-8 in password".to_string()))?;
+
+        let ok = users
+            .iter()
+            .any(|u| u.username == username && u.password == password);
+
+        if !ok {
+            let reply = PasswordAuthReply {
+                version: 0x01,
+                status: 0x01,
+            };
+            reply.encode(&mut stream).await?;
             return Err(SError::SocksError("authentication failed".to_string()));
         }
+
         let reply = PasswordAuthReply {
             version: 0x01, // authentication version not socks version
             status: SOCKS5_REPLY_SUCCEEDED,
         };
         reply.encode(&mut stream).await?;
+
         Ok(stream)
     }
-    async fn handle_socks(
-        &self,
-        s: TcpStream,
+
+    async fn handle_socks<S>(
+        mut s: S,
         local_addr: SocketAddr,
-    ) -> Result<(TcpStream, CmdReq, Option<UdpSocket>), SError> {
-        let mut s = self.authenticate(s).await?;
+        users: &[AuthUser],
+    ) -> Result<(S, CmdReq, Option<UdpSocket>), SError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send,
+    {
+        s = Self::authenticate(s, users).await?;
         let req = socks5::CmdReq::decode(&mut s).await?;
 
         let addr = match req.dst.addr {
@@ -120,11 +152,11 @@ impl SocksServer {
             rsv: 0u8,
             bind_addr: socks5::SocksAddr { addr, port: 0u16 },
         };
+
         let (reply, socket) = match req.cmd {
             SOCKS5_CMD_TCP_CONNECT => (reply, None),
             SOCKS5_CMD_UDP_ASSOCIATE => {
                 let mut local_addr = local_addr;
-
                 local_addr.set_port(0);
                 let socket = UdpSocket::bind(local_addr).await?;
                 let local_addr = socket.local_addr()?;
@@ -142,6 +174,33 @@ impl SocksServer {
         reply.encode(&mut s).await?;
         Ok((s, req, socket))
     }
+
+    pub async fn accept_stream_with_local_addr<S>(
+        stream: S,
+        local_addr: SocketAddr,
+        users: &[AuthUser],
+    ) -> Result<ProxyRequest, SError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static + TcpTrait,
+    {
+        let (s, req, socket) = SocksServer::handle_socks(stream, local_addr, users).await?;
+        match req.cmd {
+            SOCKS5_CMD_TCP_CONNECT => Ok(ProxyRequest::Tcp(TcpSession {
+                stream: Box::new(s),
+                dst: req.dst,
+            })),
+            SOCKS5_CMD_UDP_ASSOCIATE => {
+                let socket = Arc::new(socket.unwrap());
+                Ok(ProxyRequest::Udp(UdpSession {
+                    send: Arc::new(UdpSocksWrap(socket.clone(), Default::default())),
+                    recv: Box::new(UdpSocksWrap(socket, Default::default())),
+                    bind_addr: req.dst,
+                    stream: Some(Box::new(s)),
+                }))
+            }
+            _ => Err(SError::ProtocolViolation),
+        }
+    }
 }
 
 #[async_trait]
@@ -153,8 +212,7 @@ impl Inbound for SocksServer {
         // ipv4 may be mapped for dual stack socket
         let local_addr = to_ipv4_mapped(stream.local_addr().unwrap());
 
-        let (s, req, socket) = self
-            .handle_socks(stream, local_addr)
+        let (s, req, socket) = SocksServer::handle_socks(stream, local_addr, &self.users)
             .in_current_span()
             .await?;
         match req.cmd {

--- a/shadowquic/src/socks/outbound.rs
+++ b/shadowquic/src/socks/outbound.rs
@@ -1,7 +1,7 @@
 use std::{net::ToSocketAddrs, sync::Arc};
 
 use crate::{
-    TcpSession, UdpRecv, UdpSend, UdpSession,
+    HttpForwardSession, TcpSession, UdpRecv, UdpSend, UdpSession,
     msgs::socks5::{
         CmdReply, PasswordAuthReply, PasswordAuthReq, SOCKS5_AUTH_METHOD_PASSWORD,
         SOCKS5_CMD_TCP_CONNECT, SOCKS5_CMD_UDP_ASSOCIATE, SOCKS5_REPLY_SUCCEEDED, SOCKS5_RESERVE,
@@ -11,7 +11,7 @@ use crate::{
     utils::socket_opt::{SocketFactory, TcpSocketFactory, UdpSocketFactory},
 };
 use tokio::{
-    io::{AsyncReadExt, copy_bidirectional_with_sizes},
+    io::{AsyncReadExt, AsyncWriteExt, copy_bidirectional_with_sizes},
     net::{TcpStream, UdpSocket},
     sync::OnceCell,
 };
@@ -50,6 +50,7 @@ impl Outbound for SocksClient {
             match req {
                 ProxyRequest::Tcp(tcp_session) => client.handle_tcp(tcp_session).await,
                 ProxyRequest::Udp(udp_session) => client.handle_udp(udp_session).await,
+                ProxyRequest::Http(http_session) => client.handle_http(http_session).await,
             }
         };
 
@@ -242,6 +243,34 @@ impl SocksClient {
         // We can use spawn, but it requirs communication to shutdown the other
         // Flatten spawn handle using try_join! doesn't work. Don't know why
         tokio::try_join!(fut1, fut2, fut3)?;
+
+        Ok(())
+    }
+
+    async fn handle_http(&self, mut http_session: HttpForwardSession) -> Result<(), SError> {
+        tracing::info!("connect to socks server: {}", self.cfg.addr);
+
+        let tcp = TcpStream::connect(self.cfg.addr.clone()).await?;
+        tcp.set_nodelay(true)?;
+
+        let mut tcp = self.authenticate(tcp).await?;
+
+        let socksreq = CmdReq {
+            version: SOCKS5_VERSION,
+            cmd: SOCKS5_CMD_TCP_CONNECT,
+            rsv: SOCKS5_RESERVE,
+            dst: http_session.dst,
+        };
+
+        socksreq.encode(&mut tcp).await?;
+        let _rep = CmdReply::decode(&mut tcp).await?;
+        tracing::trace!("socks http forward connection established");
+
+        tcp.write_all(&http_session.first_packet).await?;
+        tcp.flush().await?;
+
+        copy_bidirectional_with_sizes(&mut tcp, &mut http_session.stream, 16 * 1024, 16 * 1024)
+            .await?;
 
         Ok(())
     }

--- a/shadowquic/src/squic/outbound.rs
+++ b/shadowquic/src/squic/outbound.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::Instrument;
-use tracing::{Level, error, info, span, trace};
+use tracing::{Level, debug, error, info, span, trace};
 
 use crate::error::SResult;
 use crate::msgs::squic::{ConnStats, ExtOpcodeConn, SQExtError, SQExtOpcode};
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use super::{SQConn, inbound::Unsplit};
+
 /// Handling a proxy request and starting proxy task with given squic connection
 pub async fn handle_request<C: QuicConnection>(
     req: ProxyRequest,
@@ -37,7 +38,6 @@ pub async fn handle_request<C: QuicConnection>(
         match req {
             crate::ProxyRequest::Tcp(mut tcp_session) => {
                 info!(dst = %tcp_session.dst, "bistream opened for tcp");
-                //let _enter = _span.enter();
                 let req = SQReq::SQConnect(tcp_session.dst.clone());
                 req.encode(&mut send).await?;
                 trace!(dst = %tcp_session.dst, "tcp connect req header sent");
@@ -47,11 +47,55 @@ pub async fn handle_request<C: QuicConnection>(
                     &mut tcp_session.stream,
                 )
                 .await?;
+
                 info!(
                     "request:{} finished, upload:{}bytes,download:{}bytes",
                     tcp_session.dst, u.1, u.0
                 );
             }
+
+            crate::ProxyRequest::Http(mut http_session) => {
+                match &http_session.dst.addr {
+                    crate::msgs::socks5::AddrOrDomain::V4(ip) => {
+                        trace!(
+                            "http dst is ipv4: {}:{}",
+                            std::net::Ipv4Addr::from(*ip),
+                            http_session.dst.port
+                        );
+                    }
+                    crate::msgs::socks5::AddrOrDomain::V6(ip) => {
+                        trace!(
+                            "http dst is ipv6: [{}]:{}",
+                            std::net::Ipv6Addr::from(*ip),
+                            http_session.dst.port
+                        );
+                    }
+                    crate::msgs::socks5::AddrOrDomain::Domain(host) => {
+                        let host =
+                            std::str::from_utf8(&host.contents).unwrap_or("<invalid-utf8-domain>");
+                        trace!("http dst is domain: {}:{}", host, http_session.dst.port);
+                    }
+                }
+
+                debug!("bistream opened for http dst:{}", http_session.dst.clone());
+
+                let req = SQReq::SQConnect(http_session.dst.clone());
+                req.encode(&mut send).await?;
+                send.write_all(&http_session.first_packet).await?;
+                send.flush().await?;
+
+                let u = tokio::io::copy_bidirectional(
+                    &mut Unsplit { s: send, r: recv },
+                    &mut http_session.stream,
+                )
+                .await?;
+
+                info!(
+                    "http request:{} finished, upload:{}bytes,download:{}bytes",
+                    http_session.dst, u.1, u.0
+                );
+            }
+
             crate::ProxyRequest::Udp(udp_session) => {
                 info!(bind_addr = %udp_session.bind_addr, "bistream opened for udp association");
                 let req = if over_stream {
@@ -59,12 +103,13 @@ pub async fn handle_request<C: QuicConnection>(
                 } else {
                     SQReq::SQAssociatOverDatagram(udp_session.bind_addr.clone())
                 };
+
                 req.encode(&mut send).await?;
                 trace!("udp associate req header sent");
+
                 let fut2 = handle_udp_recv_ctrl(recv, udp_session.send.clone(), conn.clone());
                 let fut1 = handle_udp_send(send, udp_session.recv, conn, over_stream);
-                // control stream, in socks5 inbound, end of control stream
-                // means end of udp association.
+
                 let fut3 = async {
                     if udp_session.stream.is_none() {
                         return Ok(());
@@ -105,7 +150,6 @@ pub async fn connect_tcp<C: QuicConnection>(
     let (mut send, recv, _id) = conn.open_bi().await?;
 
     info!(dst = %dst, "bistream opened for tcp");
-    //let _enter = _span.enter();
     let req = SQReq::SQConnect(dst.clone());
     req.encode(&mut send).await?;
     trace!("tcp connect req header sent");
@@ -122,6 +166,7 @@ pub async fn get_peer_conn_stats<C: QuicConnection>(
     let response = Result::<ConnStats, SQExtError>::decode(&mut recv).await?;
     Ok(response)
 }
+
 async fn print_stats<C: QuicConnection>(sq_conn: &SQConn<C>) -> SResult<()> {
     static LAST_PRINT: std::sync::LazyLock<tokio::sync::Mutex<Option<std::time::Instant>>> =
         std::sync::LazyLock::new(|| tokio::sync::Mutex::new(None));

--- a/shadowquic/src/utils/mod.rs
+++ b/shadowquic/src/utils/mod.rs
@@ -4,3 +4,5 @@ pub mod socket_opt;
 
 #[cfg(target_os = "android")]
 pub mod protect_socket;
+
+pub mod replay_stream;

--- a/shadowquic/src/utils/replay_stream.rs
+++ b/shadowquic/src/utils/replay_stream.rs
@@ -1,0 +1,71 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::TcpTrait;
+
+#[derive(Debug)]
+pub struct ReplayStream<S> {
+    prefix: io::Cursor<Vec<u8>>,
+    inner: S,
+}
+
+impl<S> ReplayStream<S> {
+    pub fn new(prefix: Vec<u8>, inner: S) -> Self {
+        Self {
+            prefix: io::Cursor::new(prefix),
+            inner,
+        }
+    }
+}
+
+impl<S> AsyncRead for ReplayStream<S>
+where
+    S: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let pos = self.prefix.position() as usize;
+        let prefix = self.prefix.get_ref();
+
+        if pos < prefix.len() {
+            let remain = &prefix[pos..];
+            let n = remain.len().min(buf.remaining());
+            buf.put_slice(&remain[..n]);
+            self.prefix.set_position((pos + n) as u64);
+            return Poll::Ready(Ok(()));
+        }
+
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for ReplayStream<S>
+where
+    S: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        data: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, data)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+impl<S> TcpTrait for ReplayStream<S> where S: TcpTrait {}

--- a/shadowquic/tests/http_proxy.rs
+++ b/shadowquic/tests/http_proxy.rs
@@ -1,0 +1,329 @@
+use std::net::SocketAddr;
+
+use shadowquic::Manager;
+use shadowquic::config::{AuthUser, MixedServerCfg, SocksClientCfg, SocksServerCfg};
+use shadowquic::direct::outbound::DirectOut;
+use shadowquic::mixed::inbound::MixedServer;
+use shadowquic::socks::inbound::SocksServer;
+use shadowquic::socks::outbound::SocksClient;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::Duration;
+
+use tracing::{Level, debug, info, trace};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::test]
+async fn test_http_head_forward() {
+    init_tracing();
+
+    let target_addr = spawn_http_target().await;
+    spawn_mixed_proxy_chain().await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut stream = TcpStream::connect("127.0.0.1:11080").await.unwrap();
+
+    let req = format!(
+        "HEAD http://{}/hello HTTP/1.1\r\n\
+         Host: {}\r\n\
+         Proxy-Connection: keep-alive\r\n\
+         User-Agent: test-http-head-forward\r\n\
+         \r\n",
+        target_addr, target_addr
+    );
+
+    stream.write_all(req.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let resp = read_to_end(&mut stream).await;
+    let text = String::from_utf8_lossy(&resp);
+
+    info!("HEAD response:\n{}", text);
+
+    assert!(
+        text.starts_with("HTTP/1.1 200 OK"),
+        "unexpected response: {}",
+        text
+    );
+    assert!(
+        text.contains("X-Method: HEAD"),
+        "response should contain X-Method: HEAD, got: {}",
+        text
+    );
+    assert!(
+        text.contains("X-Path: /hello"),
+        "response should contain X-Path: /hello, got: {}",
+        text
+    );
+}
+
+#[tokio::test]
+async fn test_http_get_forward() {
+    init_tracing();
+
+    let target_addr = spawn_http_target().await;
+    spawn_mixed_proxy_chain().await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut stream = TcpStream::connect("127.0.0.1:11080").await.unwrap();
+
+    let req = format!(
+        "GET http://{}/hello?name=shadowquic HTTP/1.1\r\n\
+         Host: {}\r\n\
+         Proxy-Connection: keep-alive\r\n\
+         User-Agent: test-http-get-forward\r\n\
+         \r\n",
+        target_addr, target_addr
+    );
+
+    stream.write_all(req.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let resp = read_to_end(&mut stream).await;
+    let text = String::from_utf8_lossy(&resp);
+
+    info!("GET response:\n{}", text);
+
+    assert!(
+        text.starts_with("HTTP/1.1 200 OK"),
+        "unexpected response: {}",
+        text
+    );
+    assert!(
+        text.contains("X-Method: GET"),
+        "response should contain X-Method: GET, got: {}",
+        text
+    );
+    assert!(
+        text.contains("X-Path: /hello?name=shadowquic"),
+        "response should contain rewritten origin-form path, got: {}",
+        text
+    );
+    assert!(
+        text.contains("X-Proxy-Connection-Seen: false"),
+        "proxy header should be stripped, got: {}",
+        text
+    );
+}
+
+#[tokio::test]
+async fn test_http_connect_tunnel() {
+    init_tracing();
+
+    let echo_addr = spawn_echo_target().await;
+    spawn_mixed_proxy_chain().await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut stream = TcpStream::connect("127.0.0.1:11080").await.unwrap();
+
+    let req = format!(
+        "CONNECT {} HTTP/1.1\r\n\
+         Host: {}\r\n\
+         \r\n",
+        echo_addr, echo_addr
+    );
+
+    stream.write_all(req.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let mut head = vec![0u8; 1024];
+    let n = stream.read(&mut head).await.unwrap();
+    let text = String::from_utf8_lossy(&head[..n]);
+
+    info!("CONNECT response:\n{}", text);
+
+    assert!(
+        text.starts_with("HTTP/1.1 200 Connection Established"),
+        "unexpected CONNECT response: {}",
+        text
+    );
+
+    let payload = b"hello through connect tunnel";
+    stream.write_all(payload).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let mut recv = vec![0u8; payload.len()];
+    stream.read_exact(&mut recv).await.unwrap();
+
+    assert_eq!(&recv, payload);
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(
+            tracing_subscriber::filter::Targets::new()
+                .with_target("shadowquic", tracing::level_filters::LevelFilter::TRACE)
+                .with_target(
+                    "http_proxy_test",
+                    tracing::level_filters::LevelFilter::TRACE,
+                ),
+        )
+        .try_init();
+
+    trace!("tracing initialized");
+}
+
+async fn spawn_mixed_proxy_chain() {
+    // entry proxy: mixed inbound -> socks outbound
+    let mixed_server = MixedServer::new(MixedServerCfg {
+        bind_addr: "127.0.0.1:11080".parse().unwrap(),
+        users: vec![],
+    })
+    .await
+    .unwrap();
+
+    let socks_client = SocksClient::new(SocksClientCfg {
+        addr: "[::1]:11094".into(),
+        username: Some("test".into()),
+        password: Some("test".into()),
+    });
+
+    let client = Manager {
+        inbound: Box::new(mixed_server),
+        outbound: Box::new(socks_client),
+    };
+
+    // upstream proxy: socks inbound -> direct outbound
+    let socks_server = SocksServer::new(SocksServerCfg {
+        bind_addr: "[::1]:11094".parse().unwrap(),
+        users: vec![AuthUser {
+            username: "test".into(),
+            password: "test".into(),
+        }],
+    })
+    .await
+    .unwrap();
+
+    let direct = DirectOut::default();
+
+    let server = Manager {
+        inbound: Box::new(socks_server),
+        outbound: Box::new(direct),
+    };
+
+    tokio::spawn(server.run());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    tokio::spawn(client.run());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+async fn spawn_http_target() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut stream, peer) = listener.accept().await.unwrap();
+            debug!("http target accepted connection from {}", peer);
+
+            tokio::spawn(async move {
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 1024];
+
+                loop {
+                    let n = stream.read(&mut tmp).await.unwrap();
+                    if n == 0 {
+                        return;
+                    }
+                    buf.extend_from_slice(&tmp[..n]);
+                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                    if buf.len() > 16 * 1024 {
+                        return;
+                    }
+                }
+
+                let req = String::from_utf8_lossy(&buf);
+                debug!("http target got request:\n{}", req);
+
+                let mut lines = req.split("\r\n");
+                let request_line = lines.next().unwrap_or_default();
+
+                let mut parts = request_line.split_whitespace();
+                let method = parts.next().unwrap_or_default();
+                let path = parts.next().unwrap_or_default();
+
+                let proxy_connection_seen = req
+                    .lines()
+                    .any(|l| l.to_ascii_lowercase().starts_with("proxy-connection:"));
+
+                let body = if method.eq_ignore_ascii_case("HEAD") {
+                    Vec::new()
+                } else {
+                    b"hello-from-target".to_vec()
+                };
+
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\n\
+                     Content-Length: {}\r\n\
+                     Connection: close\r\n\
+                     X-Method: {}\r\n\
+                     X-Path: {}\r\n\
+                     X-Proxy-Connection-Seen: {}\r\n\
+                     \r\n",
+                    body.len(),
+                    method,
+                    path,
+                    proxy_connection_seen,
+                );
+
+                stream.write_all(resp.as_bytes()).await.unwrap();
+                if !body.is_empty() {
+                    stream.write_all(&body).await.unwrap();
+                }
+                stream.flush().await.unwrap();
+            });
+        }
+    });
+
+    addr
+}
+
+async fn spawn_echo_target() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut stream, peer) = listener.accept().await.unwrap();
+            debug!("echo target accepted connection from {}", peer);
+
+            tokio::spawn(async move {
+                let mut buf = [0u8; 2048];
+                loop {
+                    let n = stream.read(&mut buf).await.unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    stream.write_all(&buf[..n]).await.unwrap();
+                    stream.flush().await.unwrap();
+                }
+            });
+        }
+    });
+
+    addr
+}
+
+async fn read_to_end(stream: &mut TcpStream) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut buf = [0u8; 2048];
+
+    loop {
+        match tokio::time::timeout(Duration::from_secs(3), stream.read(&mut buf)).await {
+            Ok(Ok(0)) => break,
+            Ok(Ok(n)) => out.extend_from_slice(&buf[..n]),
+            Ok(Err(e)) => panic!("read failed: {e}"),
+            Err(_) => break,
+        }
+    }
+
+    out
+}


### PR DESCRIPTION
This change adds a built-in HTTP proxy implementation to the mixed
inbound, allowing a single listening port to accept both SOCKS5 and
HTTP proxy traffic.

A key design goal here is to keep the implementation lightweight and
almost crate-free. Instead of pulling in a full HTTP server/parser
stack, the proxy is implemented directly on top of the existing stream
model, with `base64` being the only new dependency for Basic
authentication support.

This is primarily a usability feature.

The intention is not to make shadowquic compete with full-featured
frontend/inbound solutions such as clash-rs or xray-core. Those
projects target a much broader set of protocols and advanced control
planes. In contrast, this HTTP proxy support is meant to provide a
practical out-of-box mixed server so users can immediately use
shadowquic as a real proxy endpoint.

As an example, once the mixed listener is running, an HTTP client can
route requests through it with a single environment variable:

  $ https_proxy=http://127.0.0.1:10808 wget https://example.com

Benefits:

- SOCKS5 and HTTP proxy on the same port
- works with clients that only support HTTP proxy settings
- no need to deploy an extra HTTP proxy server alongside shadowquic
- simpler local and edge deployments
- minimal dependency and maintenance cost