### PR TITLE
feat(observe): enable statistics on 32-bit targets via portable-atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,6 +2043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +2914,7 @@ dependencies = [
  "noq",
  "noq-proto",
  "notify",
+ "portable-atomic",
  "qbase 0.5.1",
  "qevent 0.5.1",
  "quinn-jls",

--- a/document/api.md
+++ b/document/api.md
@@ -102,8 +102,8 @@ udp_recv: 777
 `tcp_recv` and `udp_recv` count bytes received by the server from the client.
 
 Traffic statistics require the `statistics` feature, which is enabled by
-default on targets with 64-bit atomics. On targets without 64-bit atomics, such
-as 32-bit MIPS, statistics are disabled and this command returns zero counters.
+default. On targets without native 64-bit atomics, such as 32-bit MIPS,
+counters are emulated with `portable-atomic` and remain functional.
 
 To fetch stats for every configured user, omit the username:
 

--- a/shadowquic/Cargo.toml
+++ b/shadowquic/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true}
 readme = { workspace = true}
 [features]
 default = ["shadowquic-quinn", "sunnyquic-noq", "ring", "statistics", "tproxy", "mixed"]
-statistics = []
+statistics = ["dep:portable-atomic"]
 mixed = ["dep:base64"]
 ring = [
     "dep:ring",
@@ -93,6 +93,10 @@ etherparse = { version = "0.14.3", optional = true }
 [target.'cfg(target_os="linux")'.dependencies]
 libc = { version = "0.2", optional = true }
 etherparse = { version = "0.14.3", optional = true }
+
+# 64-bit atomics via ll/sc CAS loop on targets without native AtomicU64 (e.g. 32-bit MIPS)
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = { version = "1", optional = true }
 [target.'cfg(target_os="android")'.dependencies]
 sendfd = { version = "0.4.4", features = ["tokio"] }
 

--- a/shadowquic/src/observe/imple.rs
+++ b/shadowquic/src/observe/imple.rs
@@ -1,11 +1,13 @@
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::{AtomicU64, Ordering};
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use std::{
     collections::HashMap,
     io::{self, IoSlice},
     pin::Pin,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::Arc,
     task::{Context, Poll},
 };
 

--- a/shadowquic/src/observe/mod.rs
+++ b/shadowquic/src/observe/mod.rs
@@ -1,9 +1,9 @@
-#[cfg(all(feature = "statistics", target_has_atomic = "64"))]
+#[cfg(feature = "statistics")]
 mod imple;
-#[cfg(not(all(feature = "statistics", target_has_atomic = "64")))]
+#[cfg(not(feature = "statistics"))]
 mod unimpl;
 
-#[cfg(all(feature = "statistics", target_has_atomic = "64"))]
+#[cfg(feature = "statistics")]
 pub use self::imple::*;
-#[cfg(not(all(feature = "statistics", target_has_atomic = "64")))]
+#[cfg(not(feature = "statistics"))]
 pub use self::unimpl::*;


### PR DESCRIPTION
## Enable statistics on targets without 64-bit atomics

`statistics` was gated on `target_has_atomic = "64"`, so on 32-bit MIPS (OpenWrt mipsel builds) it silently compiled to a no-op stub and `get-stats` always returned zero — despite `statistics` being a default feature.

The counters are `Arc<AtomicU64>`, which `std` doesn't provide on such targets. This PR swaps in [`portable-atomic`](https://crates.io/crates/portable-atomic): on MIPS32 it emulates `AtomicU64` lock-free via an `ll`/`sc` CAS loop (no `critical-section` needed), with an identical API, so the counter code is untouched.

Changes:

- `shadowquic/Cargo.toml` — `portable-atomic` as a target-gated optional dep, wired to the `statistics` feature. 64-bit targets never compile it; they keep using native `std` atomics.
- `observe/mod.rs` — drop the `target_has_atomic` gate; module selection now depends only on the feature.
- `observe/imple.rs` — cfg'd import of `AtomicU64`/`Ordering` (`std` vs `portable_atomic`).
- `document/api.md`, `Cargo.lock` — docs + lockfile updates.

`unimpl.rs` is kept as the fallback for `--no-default-features` builds.