### PR TITLE
feat: add api clear-stats to reset per-user traffic stats

### DIFF
--- a/PROTOCOL.typ
+++ b/PROTOCOL.typ
@@ -442,6 +442,14 @@ The supported `USER OPCODE` values are:
   [`GetAllStats`],
   [Empty],
   [`Result<Vec<UserStats>, SQExtError>`],
+  [`0x6`],
+  [`ClearUserStats`],
+  [`UserName`],
+  [`Result<(), SQExtError>`],
+  [`0x7`],
+  [`ClearAllStats`],
+  [Empty],
+  [`Result<(), SQExtError>`],
 )
 
 `AuthUser` contains two strings:

--- a/document/api.md
+++ b/document/api.md
@@ -134,6 +134,46 @@ udp_sent: 777
 udp_recv: 777
 ```
 
+### `clear-stats [username]`
+
+Zero the cumulative traffic byte counters (`tcp_sent`, `tcp_recv`, `udp_sent`,
+`udp_recv`) for one user, or every configured user when `username` is omitted.
+
+```sh
+shadowquic api clear-stats alice
+```
+
+On success, the command prints:
+
+```text
+user stats cleared: alice
+```
+
+Omitting the username clears every configured user:
+
+```sh
+shadowquic api clear-stats
+```
+
+```text
+all user stats cleared
+```
+
+Only the four byte counters are reset. The live connection counters
+(`conn_num`, `tcp_conns`, `udp_conns`) are not touched. Active connections keep
+counting bytes from zero after the reset.
+
+The reset is best-effort: the four counters are zeroed independently rather than
+as one atomic snapshot, so under active traffic a concurrent `get-stats` may
+briefly observe a mix of zeroed and un-zeroed counters.
+
+Only the admin user (`admin`, `admin_bob`, ...) can run this command; other
+users get `PermissionDenied`. Clearing stats of a user that does not exist fails
+with `NotFound`.
+
+Both the client and the server must run a version that supports `clear-stats`;
+an older server does not recognize the request.
+
 ### `kill-conn <username>`
 
 Close all online QUIC connections for a user.

--- a/shadowquic/src/main.rs
+++ b/shadowquic/src/main.rs
@@ -56,6 +56,9 @@ enum ApiCommand {
     /// Kill all online connections for a user
     #[command(name = "kill-conn")]
     KillUserConn { username: String },
+    /// Clear traffic stats for a user, or all users when username is omitted
+    #[command(name = "clear-stats")]
+    ClearUserStats { username: Option<String> },
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 8)]
@@ -170,6 +173,24 @@ async fn call_user_manager_api(
                 .await
                 .map_err(|error| format!("kill-conn of user {username} failed: {error:?}"))?;
             println!("user connections killed: {username}");
+            Ok(())
+        }
+        ApiCommand::ClearUserStats {
+            username: Some(username),
+        } => {
+            user_manager
+                .clear_user_stats(&username)
+                .await
+                .map_err(|error| format!("clear-stats of user {username} failed: {error:?}"))?;
+            println!("user stats cleared: {username}");
+            Ok(())
+        }
+        ApiCommand::ClearUserStats { username: None } => {
+            user_manager
+                .clear_all_stats()
+                .await
+                .map_err(|error| format!("clear-stats of all users failed: {error:?}"))?;
+            println!("all user stats cleared");
             Ok(())
         }
     }

--- a/shadowquic/src/msgs/squic.rs
+++ b/shadowquic/src/msgs/squic.rs
@@ -60,6 +60,8 @@ pub enum ExtOpcodeUser {
     GetUserStats(UserName) = 0x3,
     KillUserConn(UserName) = 0x4,
     GetAllStats = 0x5,
+    ClearUserStats(UserName) = 0x6,
+    ClearAllStats = 0x7,
 }
 #[derive(PartialEq)]
 #[repr(u8)]

--- a/shadowquic/src/observe/imple.rs
+++ b/shadowquic/src/observe/imple.rs
@@ -52,6 +52,13 @@ impl ProxyStatsAtm {
             self.udp_conns.clone(),
         )
     }
+
+    fn reset(&self) {
+        self.tcp_sent.store(0, Ordering::Relaxed);
+        self.tcp_recv.store(0, Ordering::Relaxed);
+        self.udp_sent.store(0, Ordering::Relaxed);
+        self.udp_recv.store(0, Ordering::Relaxed);
+    }
 }
 
 #[derive(Clone, Default)]
@@ -132,6 +139,21 @@ impl Observer {
             UserStats {
                 username: username.to_owned(),
                 ..Default::default()
+            }
+        }
+    }
+
+    pub async fn clear_user_stats(&self, username: &str) {
+        if let Some(stats) = self.user_stats.lock().await.get(username) {
+            stats.reset();
+        }
+    }
+
+    pub async fn clear_all_stats(&self, usernames: &[String]) {
+        let user_stats = self.user_stats.lock().await;
+        for username in usernames {
+            if let Some(stats) = user_stats.get(username) {
+                stats.reset();
             }
         }
     }

--- a/shadowquic/src/observe/unimpl.rs
+++ b/shadowquic/src/observe/unimpl.rs
@@ -33,6 +33,10 @@ impl Observer {
         Vec::new()
     }
 
+    pub async fn clear_user_stats(&self, _username: &str) {}
+
+    pub async fn clear_all_stats(&self, _usernames: &[String]) {}
+
     pub(crate) async fn wrap_request(&self, req: ProxyRequest) -> ProxyRequest {
         req
     }

--- a/shadowquic/src/shadowquic/inbound.rs
+++ b/shadowquic/src/shadowquic/inbound.rs
@@ -114,6 +114,28 @@ impl UserManager for ShadowQuicUserManager {
         self.observer.close_conn(username).await;
         Ok(())
     }
+
+    async fn clear_user_stats(&self, username: &str) -> Result<(), SQExtError> {
+        let config = self.config.read().await;
+        if !config.users.iter().any(|user| user.username == username) {
+            return Err(SQExtError::NotFound);
+        }
+        drop(config);
+        self.observer.clear_user_stats(username).await;
+        Ok(())
+    }
+
+    async fn clear_all_stats(&self) -> Result<(), SQExtError> {
+        let config = self.config.read().await;
+        let usernames = config
+            .users
+            .iter()
+            .map(|user| user.username.clone())
+            .collect::<Vec<_>>();
+        drop(config);
+        self.observer.clear_all_stats(&usernames).await;
+        Ok(())
+    }
 }
 
 impl ShadowQuicServer {

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -157,6 +157,26 @@ impl UserManager for ShadowQuicClient {
             .await
             .map_err(|error| SQExtError::Other(error.to_string()))?
     }
+
+    async fn clear_user_stats(&self, username: &str) -> Result<(), SQExtError> {
+        let conn = self
+            .get_conn()
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?;
+        outbound::clear_user_stats(&conn, username)
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?
+    }
+
+    async fn clear_all_stats(&self) -> Result<(), SQExtError> {
+        let conn = self
+            .get_conn()
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?;
+        outbound::clear_all_stats(&conn)
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?
+    }
 }
 
 #[async_trait]

--- a/shadowquic/src/squic/inbound.rs
+++ b/shadowquic/src/squic/inbound.rs
@@ -36,6 +36,8 @@ pub trait UserManager: Send + Sync {
     async fn get_user_stats(&self, username: &str) -> Result<UserStats, SQExtError>;
     async fn get_all_stats(&self) -> Result<Vec<UserStats>, SQExtError>;
     async fn kill_user_conns(&self, username: &str) -> Result<(), SQExtError>;
+    async fn clear_user_stats(&self, username: &str) -> Result<(), SQExtError>;
+    async fn clear_all_stats(&self) -> Result<(), SQExtError>;
 }
 
 #[derive(Clone)]
@@ -235,6 +237,18 @@ impl<C: QuicConnection> SQServerConn<C> {
                     .await
                     .encode(send)
                     .await?;
+            }
+            ExtOpcodeUser::ClearUserStats(username) => {
+                info!(username = %username, "clearing user stats");
+                user_manager
+                    .clear_user_stats(&username)
+                    .await
+                    .encode(send)
+                    .await?;
+            }
+            ExtOpcodeUser::ClearAllStats => {
+                info!("clearing all user stats");
+                user_manager.clear_all_stats().await.encode(send).await?;
             }
         }
         Ok(())

--- a/shadowquic/src/squic/outbound.rs
+++ b/shadowquic/src/squic/outbound.rs
@@ -176,6 +176,19 @@ pub async fn kill_user_conns<C: QuicConnection>(
     send_user_extension(sq_conn, ExtOpcodeUser::KillUserConn(username.to_owned())).await
 }
 
+pub async fn clear_user_stats<C: QuicConnection>(
+    sq_conn: &SQConn<C>,
+    username: &str,
+) -> SResult<Result<(), SQExtError>> {
+    send_user_extension(sq_conn, ExtOpcodeUser::ClearUserStats(username.to_owned())).await
+}
+
+pub async fn clear_all_stats<C: QuicConnection>(
+    sq_conn: &SQConn<C>,
+) -> SResult<Result<(), SQExtError>> {
+    send_user_extension(sq_conn, ExtOpcodeUser::ClearAllStats).await
+}
+
 async fn send_user_extension<C: QuicConnection, R: SDecode>(
     sq_conn: &SQConn<C>,
     opcode: ExtOpcodeUser,

--- a/shadowquic/src/sunnyquic/inbound.rs
+++ b/shadowquic/src/sunnyquic/inbound.rs
@@ -119,6 +119,28 @@ impl UserManager for SunnyQuicUserManager {
         self.observer.close_conn(username).await;
         Ok(())
     }
+
+    async fn clear_user_stats(&self, username: &str) -> Result<(), SQExtError> {
+        let config = self.config.read().await;
+        if !config.users.iter().any(|user| user.username == username) {
+            return Err(SQExtError::NotFound);
+        }
+        drop(config);
+        self.observer.clear_user_stats(username).await;
+        Ok(())
+    }
+
+    async fn clear_all_stats(&self) -> Result<(), SQExtError> {
+        let config = self.config.read().await;
+        let usernames = config
+            .users
+            .iter()
+            .map(|user| user.username.clone())
+            .collect::<Vec<_>>();
+        drop(config);
+        self.observer.clear_all_stats(&usernames).await;
+        Ok(())
+    }
 }
 
 impl SunnyQuicServer {

--- a/shadowquic/src/sunnyquic/outbound.rs
+++ b/shadowquic/src/sunnyquic/outbound.rs
@@ -167,6 +167,26 @@ impl UserManager for SunnyQuicClient {
             .await
             .map_err(|error| SQExtError::Other(error.to_string()))?
     }
+
+    async fn clear_user_stats(&self, username: &str) -> Result<(), SQExtError> {
+        let conn = self
+            .get_conn()
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?;
+        outbound::clear_user_stats(&conn, username)
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?
+    }
+
+    async fn clear_all_stats(&self) -> Result<(), SQExtError> {
+        let conn = self
+            .get_conn()
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?;
+        outbound::clear_all_stats(&conn)
+            .await
+            .map_err(|error| SQExtError::Other(error.to_string()))?
+    }
 }
 
 #[async_trait]

--- a/shadowquic/tests/shadowquic_user_api.rs
+++ b/shadowquic/tests/shadowquic_user_api.rs
@@ -24,6 +24,7 @@ use tokio::{
 const SERVER_ADDR: &str = "127.0.0.1:4458";
 const STATS_SERVER_ADDR: &str = "127.0.0.1:4468";
 const TRAFFIC_STATS_SERVER_ADDR: &str = "127.0.0.1:4478";
+const CLEAR_STATS_SERVER_ADDR: &str = "127.0.0.1:4488";
 const TCP_STATS_BYTES: usize = 4096;
 const UDP_STATS_BYTES: usize = 777;
 
@@ -291,6 +292,173 @@ async fn shadowquic_user_api_get_stats_tracks_tcp_and_udp_bytes() {
     })
     .await
     .expect("traffic stats should be updated");
+}
+
+#[tokio::test]
+async fn shadowquic_user_api_clear_stats() {
+    let tcp_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("tcp echo listener should bind");
+    let tcp_addr = tcp_listener.local_addr().unwrap();
+    let udp_socket = UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("udp echo socket should bind");
+    let udp_addr = udp_socket.local_addr().unwrap();
+
+    tokio::spawn(tcp_echo_once(tcp_listener, TCP_STATS_BYTES));
+    tokio::spawn(udp_echo_once(udp_socket, UDP_STATS_BYTES));
+
+    let sq_server = ShadowQuicServer::new(ShadowQuicServerCfg {
+        bind_addr: CLEAR_STATS_SERVER_ADDR.parse().unwrap(),
+        users: vec![
+            AuthUser {
+                username: "admin".into(),
+                password: "admin-pass".into(),
+            },
+            AuthUser {
+                username: "bob".into(),
+                password: "bob-pass".into(),
+            },
+        ],
+        jls_upstream: JlsUpstream {
+            addr: "localhost:443".into(),
+            ..Default::default()
+        },
+        alpn: vec!["h3".into()],
+        zero_rtt: false,
+        gso: false,
+        initial_mtu: default_initial_mtu(),
+        congestion_control: CongestionControl::Bbr,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    let server = Manager {
+        inbound: Box::new(sq_server),
+        outbound: Box::<DirectOut>::default(),
+    };
+    tokio::spawn(server.run());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let admin = client_at(CLEAR_STATS_SERVER_ADDR, "admin", "admin-pass");
+    let bob = client_at(CLEAR_STATS_SERVER_ADDR, "bob", "bob-pass");
+    let bob_conn = bob.get_conn().await.expect("bob should connect");
+
+    let tcp_payload = vec![0x5a; TCP_STATS_BYTES];
+    let mut tcp_stream = connect_tcp(&bob_conn, SocksAddr::from(tcp_addr))
+        .await
+        .expect("tcp request should open");
+    tcp_stream.write_all(&tcp_payload).await.unwrap();
+    tcp_stream.flush().await.unwrap();
+    let mut tcp_echo = vec![0; TCP_STATS_BYTES];
+    tcp_stream.read_exact(&mut tcp_echo).await.unwrap();
+    assert_eq!(tcp_echo, tcp_payload);
+
+    let udp_payload = Bytes::from(vec![0xa5; UDP_STATS_BYTES]);
+    let udp_bind: SocketAddr = "0.0.0.0:0".parse().unwrap();
+    let (udp_send, mut udp_recv) = associate_udp(&bob_conn, SocksAddr::from(udp_bind), true)
+        .await
+        .expect("udp association should open");
+    udp_send
+        .send((udp_payload.clone(), SocksAddr::from(udp_addr)))
+        .await
+        .expect("udp payload should send");
+    let (udp_echo, _) = tokio::time::timeout(Duration::from_secs(2), udp_recv.recv())
+        .await
+        .expect("udp echo should arrive before timeout")
+        .expect("udp echo channel should stay open");
+    assert_eq!(udp_echo, udp_payload);
+
+    async fn wait_bob_stats(
+        admin: &ShadowQuicClient,
+        tcp_recv: u64,
+        tcp_sent: u64,
+        udp_recv: u64,
+        udp_sent: u64,
+    ) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let stats = admin
+                    .get_user_stats("bob")
+                    .await
+                    .expect("admin should get bob stats");
+                if stats.tcp_recv == tcp_recv
+                    && stats.tcp_sent == tcp_sent
+                    && stats.udp_recv == udp_recv
+                    && stats.udp_sent == udp_sent
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("traffic stats should be updated");
+    }
+
+    let bytes = TCP_STATS_BYTES as u64;
+    let udp_bytes = UDP_STATS_BYTES as u64;
+    wait_bob_stats(&admin, bytes, bytes, udp_bytes, udp_bytes).await;
+
+    admin
+        .clear_user_stats("bob")
+        .await
+        .expect("admin should clear bob stats");
+    let stats = admin
+        .get_user_stats("bob")
+        .await
+        .expect("admin should get bob stats after clear");
+    assert_eq!(stats.tcp_recv, 0);
+    assert_eq!(stats.tcp_sent, 0);
+    assert_eq!(stats.udp_recv, 0);
+    assert_eq!(stats.udp_sent, 0);
+    assert_eq!(stats.tcp_conns, 1);
+    assert_eq!(stats.udp_conns, 1);
+    assert_eq!(stats.conn_num, 1);
+
+    let tcp_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("second tcp echo listener should bind");
+    let tcp_addr = tcp_listener.local_addr().unwrap();
+    tokio::spawn(tcp_echo_once(tcp_listener, TCP_STATS_BYTES));
+    let mut tcp_stream = connect_tcp(&bob_conn, SocksAddr::from(tcp_addr))
+        .await
+        .expect("second tcp request should open");
+    tcp_stream.write_all(&tcp_payload).await.unwrap();
+    tcp_stream.flush().await.unwrap();
+    let mut tcp_echo = vec![0; TCP_STATS_BYTES];
+    tcp_stream.read_exact(&mut tcp_echo).await.unwrap();
+    assert_eq!(tcp_echo, tcp_payload);
+    wait_bob_stats(&admin, bytes, bytes, 0, 0).await;
+
+    admin
+        .clear_all_stats()
+        .await
+        .expect("admin should clear all stats");
+    let all_stats = admin
+        .get_all_stats()
+        .await
+        .expect("admin should get all stats after clear");
+    for stats in all_stats {
+        assert_eq!(stats.tcp_recv, 0);
+        assert_eq!(stats.tcp_sent, 0);
+        assert_eq!(stats.udp_recv, 0);
+        assert_eq!(stats.udp_sent, 0);
+    }
+
+    assert_eq!(
+        bob.clear_user_stats("bob").await,
+        Err(SQExtError::PermissionDenied)
+    );
+    assert_eq!(
+        bob.clear_all_stats().await,
+        Err(SQExtError::PermissionDenied)
+    );
+    assert_eq!(
+        admin.clear_user_stats("missing").await,
+        Err(SQExtError::NotFound)
+    );
 }
 
 fn client(username: &str, password: &str) -> ShadowQuicClient {


### PR DESCRIPTION
Add `shadowquic api clear-stats [username]` to reset cumulative traffic statistics.

- `clear-stats <username>` resets `tcp_sent`, `tcp_recv`, `udp_sent`, and `udp_recv` for one user.
- `clear-stats` resets those counters for all configured users.
- Live connection counters (`conn_num`, `tcp_conns`, `udp_conns`) are preserved.
- Restricted to admin users; missing users return `NotFound`.
- Adds protocol opcodes, client/server handling, documentation, and integration coverage for ShadowQuic.