### PR TITLE
feat: periodically log uplink/downlink link quality on a single connection

### DIFF
--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -129,7 +129,16 @@ impl OutboundCfg {
                 }
                 Box::new(ShadowQuicClient::new(cfg))
             }
-            OutboundCfg::SunnyQuic(cfg) => Box::new(SunnyQuicClient::new(cfg)),
+            OutboundCfg::SunnyQuic(cfg) => {
+                if cfg.stats_log_interval != 0 {
+                    warn!(
+                        "stats_log_interval is set: periodic link-quality logging queries \
+                         downlink stats over the QUIC connection every interval, keeping the \
+                         connection alive so it will not idle out"
+                    );
+                }
+                Box::new(SunnyQuicClient::new(cfg))
+            }
             OutboundCfg::Direct(cfg) => Box::new(DirectOut::new(cfg)),
         };
         Ok(r)

--- a/shadowquic/src/config/mod.rs
+++ b/shadowquic/src/config/mod.rs
@@ -119,7 +119,16 @@ impl OutboundCfg {
     async fn build_outbound(self) -> Result<Box<dyn Outbound>, SError> {
         let r: Box<dyn Outbound> = match self {
             OutboundCfg::Socks(cfg) => Box::new(SocksClient::new(cfg)),
-            OutboundCfg::ShadowQuic(cfg) => Box::new(ShadowQuicClient::new(cfg)),
+            OutboundCfg::ShadowQuic(cfg) => {
+                if cfg.stats_log_interval != 0 {
+                    warn!(
+                        "stats_log_interval is set: periodic link-quality logging queries \
+                         downlink stats over the QUIC connection every interval, keeping the \
+                         connection alive so it will not idle out"
+                    );
+                }
+                Box::new(ShadowQuicClient::new(cfg))
+            }
             OutboundCfg::SunnyQuic(cfg) => Box::new(SunnyQuicClient::new(cfg)),
             OutboundCfg::Direct(cfg) => Box::new(DirectOut::new(cfg)),
         };

--- a/shadowquic/src/config/shadowquic.rs
+++ b/shadowquic/src/config/shadowquic.rs
@@ -16,6 +16,10 @@ pub fn default_rate_limit() -> u64 {
     u64::MAX
 }
 
+pub fn default_stats_log_interval() -> u64 {
+    0
+}
+
 /// Configuration of shadowquic inbound
 ///
 /// Example:
@@ -160,6 +164,7 @@ impl Default for ShadowQuicClientCfg {
             cipher_suite_preference: None,
             socket_opt: Default::default(),
             protect_path: Default::default(),
+            stats_log_interval: default_stats_log_interval(),
         }
     }
 }
@@ -283,6 +288,11 @@ pub struct ShadowQuicClientCfg {
     /// Socket options like bind interface and fwmark
     #[serde(flatten)]
     pub socket_opt: SocketOpt,
+
+    /// Interval in seconds for periodically logging uplink/downlink link quality.
+    /// 0 (default) keeps the legacy once-per-request logging.
+    #[serde(default = "default_stats_log_interval")]
+    pub stats_log_interval: u64,
 }
 
 impl HasCipherSuitePreference for ShadowQuicClientCfg {

--- a/shadowquic/src/config/sunnyquic.rs
+++ b/shadowquic/src/config/sunnyquic.rs
@@ -6,7 +6,7 @@ use crate::config::{
     AuthUser, BrutalParams, CipherSuitePreference, CongestionControl, HasCipherSuitePreference,
     SocketOpt, default_alpn, default_congestion_control, default_gso, default_initial_mtu,
     default_keep_alive_interval, default_min_mtu, default_mtu_discovery, default_over_stream,
-    default_store_flush_interval, default_zero_rtt,
+    default_stats_log_interval, default_store_flush_interval, default_zero_rtt,
 };
 
 pub(crate) fn default_multipath_num() -> u32 {
@@ -129,6 +129,7 @@ impl Default for SunnyQuicClientCfg {
             over_stream: Default::default(),
             min_mtu: default_min_mtu(),
             keep_alive_interval: default_keep_alive_interval(),
+            stats_log_interval: default_stats_log_interval(),
             max_path_num: default_multipath_num(),
             extra_paths: Default::default(),
             cert_path: Default::default(),
@@ -211,6 +212,10 @@ pub struct SunnyQuicClientCfg {
     /// Disabled by default.
     #[serde(default = "default_keep_alive_interval")]
     pub keep_alive_interval: u32,
+    /// Interval in seconds for periodically logging uplink/downlink link quality.
+    /// 0 (default) keeps the legacy once-per-request logging.
+    #[serde(default = "default_stats_log_interval")]
+    pub stats_log_interval: u64,
     /// Enable QUIC Generic Segmentation Offload (GSO).
     /// Controls [`quinn::TransportConfig::enable_segmentation_offload`]. When supported, GSO reduces
     /// CPU usage for bulk sends; unsupported environments may see transient startup packet loss.

--- a/shadowquic/src/shadowquic/outbound.rs
+++ b/shadowquic/src/shadowquic/outbound.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use std::{net::ToSocketAddrs, sync::Arc};
+use std::{net::ToSocketAddrs, sync::Arc, time::Duration};
 use tokio::sync::{OnceCell, SetOnce};
 
 use super::quinn_wrapper::EndClient;
@@ -78,6 +78,17 @@ impl ShadowQuicClient {
                 .await
                 .map_err(|x| error!("handle udp packet recv error: {}", x));
         });
+        let stats_log_interval = self.config.stats_log_interval;
+        if stats_log_interval > 0 {
+            let conn_clone = conn.clone();
+            tokio::spawn(async move {
+                outbound::report_stats_periodically(
+                    conn_clone,
+                    Duration::from_secs(stats_log_interval),
+                )
+                .await;
+            });
+        }
         Ok(conn)
     }
     async fn prepare_conn(&mut self) -> Result<(), SError> {
@@ -187,7 +198,7 @@ impl Outbound for ShadowQuicClient {
         let conn = self.quic_conn.as_mut().unwrap().clone();
 
         let over_stream = self.config.over_stream;
-        outbound::handle_request(req, conn, over_stream).await?;
+        outbound::handle_request(req, conn, over_stream, self.config.stats_log_interval).await?;
         Ok(())
     }
 }

--- a/shadowquic/src/squic/outbound.rs
+++ b/shadowquic/src/squic/outbound.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 
@@ -27,16 +28,21 @@ pub async fn handle_request<C: QuicConnection>(
     req: ProxyRequest,
     conn: SQConn<C>,
     over_stream: bool,
+    stats_log_interval: u64,
 ) -> Result<(), SError> {
     let (mut send, recv, id) = QuicConnection::open_bi(&conn.conn).await?;
     let _span = span!(Level::INFO, "bistream", id = id);
-    let conn_clone = conn.clone();
-    tokio::spawn(
-        async move {
-            let _ = print_stats(&conn_clone).await;
-        }
-        .in_current_span(),
-    );
+    // With periodic logging disabled (interval 0), keep the legacy behavior of
+    // printing stats once per new request.
+    if stats_log_interval == 0 {
+        let conn_clone = conn.clone();
+        tokio::spawn(
+            async move {
+                let _ = print_stats_throttled(&conn_clone).await;
+            }
+            .in_current_span(),
+        );
+    }
     let fut = async move {
         match req {
             crate::ProxyRequest::Tcp(mut tcp_session) => {
@@ -200,7 +206,73 @@ async fn send_user_extension<C: QuicConnection, R: SDecode>(
     Ok(response)
 }
 
-async fn print_stats<C: QuicConnection>(sq_conn: &SQConn<C>) -> SResult<()> {
+/// Only one connection may print link quality logs at a time, to avoid spamming
+/// the log when multiple connections are alive.
+static STATS_LOG_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Shortest interval at which the connection-closed state is polled, so the
+/// reporter role is released promptly once the connection closes.
+const CLOSE_POLL: Duration = Duration::from_secs(1);
+
+/// RAII guard that clears the global reporter flag on drop, so the role is
+/// released even if the reporter task is cancelled or panics.
+struct StatsLogActiveGuard;
+
+impl Drop for StatsLogActiveGuard {
+    fn drop(&mut self) {
+        STATS_LOG_ACTIVE.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Periodically prints uplink/downlink link quality logs until the connection
+/// closes. The first print happens immediately, then once per `interval`.
+/// Only one connection prints at a time; connections that fail to claim the
+/// role wait for the owner to release it instead of giving up.
+pub async fn report_stats_periodically<C: QuicConnection>(sq_conn: SQConn<C>, interval: Duration) {
+    if interval.is_zero() {
+        return;
+    }
+
+    // Compete to become the sole reporter; if not claimed, wait for the owner
+    // to release it, or exit if this connection closes.
+    loop {
+        if STATS_LOG_ACTIVE
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            break;
+        }
+        if sq_conn.close_reason().is_some() {
+            return;
+        }
+        tokio::time::sleep(CLOSE_POLL).await;
+    }
+    // From here on the flag is guaranteed to be released when this future ends,
+    // whether by normal return, cancellation, or panic.
+    let _active_guard = StatsLogActiveGuard;
+
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {
+                if sq_conn.close_reason().is_some() {
+                    break;
+                }
+                let _ = print_stats(&sq_conn).await;
+            }
+            _ = tokio::time::sleep(CLOSE_POLL) => {
+                if sq_conn.close_reason().is_some() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Legacy per-request stats logging used when periodic logging is disabled.
+/// Prints at most once every 10 seconds across all connections.
+async fn print_stats_throttled<C: QuicConnection>(sq_conn: &SQConn<C>) -> SResult<()> {
     static LAST_PRINT: std::sync::LazyLock<tokio::sync::Mutex<Option<std::time::Instant>>> =
         std::sync::LazyLock::new(|| tokio::sync::Mutex::new(None));
 
@@ -214,6 +286,10 @@ async fn print_stats<C: QuicConnection>(sq_conn: &SQConn<C>) -> SResult<()> {
         *last_print = Some(std::time::Instant::now());
     }
 
+    print_stats(sq_conn).await
+}
+
+async fn print_stats<C: QuicConnection>(sq_conn: &SQConn<C>) -> SResult<()> {
     let stats = sq_conn.get_conn_stats().ok_or(SError::ProtocolUnimpl)?;
     info!(
         packet_loss_rate=%format!("{:.2}%", stats.lost_packets as f32 / (stats.sent_packets + 1) as f32 * 100.0),

--- a/shadowquic/src/sunnyquic/outbound.rs
+++ b/shadowquic/src/sunnyquic/outbound.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use std::{net::ToSocketAddrs, sync::Arc};
+use std::{net::ToSocketAddrs, sync::Arc, time::Duration};
 use tokio::sync::{OnceCell, SetOnce};
 
 use super::EndClient;
@@ -88,6 +88,17 @@ impl SunnyQuicClient {
                 .await
                 .map_err(|x| error!("handle udp packet recv error: {}", x));
         });
+        let stats_log_interval = self.config.stats_log_interval;
+        if stats_log_interval > 0 {
+            let conn_clone = conn.clone();
+            tokio::spawn(async move {
+                outbound::report_stats_periodically(
+                    conn_clone,
+                    Duration::from_secs(stats_log_interval),
+                )
+                .await;
+            });
+        }
         Ok(conn)
     }
     async fn prepare_conn(&mut self) -> Result<(), SError> {
@@ -197,7 +208,7 @@ impl Outbound for SunnyQuicClient {
         let conn = self.quic_conn.as_mut().unwrap().clone();
 
         let over_stream = self.config.over_stream;
-        outbound::handle_request(req, conn, over_stream, 0).await?;
+        outbound::handle_request(req, conn, over_stream, self.config.stats_log_interval).await?;
         Ok(())
     }
 }

--- a/shadowquic/src/sunnyquic/outbound.rs
+++ b/shadowquic/src/sunnyquic/outbound.rs
@@ -197,7 +197,7 @@ impl Outbound for SunnyQuicClient {
         let conn = self.quic_conn.as_mut().unwrap().clone();
 
         let over_stream = self.config.over_stream;
-        outbound::handle_request(req, conn, over_stream).await?;
+        outbound::handle_request(req, conn, over_stream, 0).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Problem

Uplink/downlink link-quality stats (packet loss, RTT, MTU) are only logged
when a new bistream opens, via `handle_request`, throttled to once per 10s by
a global mutex. That ties the sample rate to *application connection churn*
instead of *link dynamics*:

- A single long-lived stream (e.g. a YouTube video or a large download)
  opens no new bistreams for its whole duration, so it emits **zero samples
  exactly while the link is carrying the most traffic** — the moment you most
  need to see loss/RTT drifting.
- A burst of new connections emits a burst of samples that reflect "the user
  is clicking", not "the link changed".

The result is a sparse, request-correlated signal that is unusable as a
continuous link-quality time series. One concrete downstream consumer is our
[xtp-rs](https://github.com/hrimfaxi/xtp-rs) deployment, where [stats_reporter.sh](https://github.com/hrimfaxi/xtp-rs/blob/master/contrib/usr/libexec/xtp-rs/stats_reporter.sh) parses these log lines and feeds
them into xtp-rs over a Unix datagram socket to rank multiple upstreams.
With per-bistream sampling, an upstream that is actively serving traffic
stops emitting fresh samples and its score goes stale, so routing decisions
are made on outdated information.

## Change

Add a `stats-log-interval` outbound option (seconds):

- `0` (default): keep the current behavior — log once per new request,
  throttled to once per 10s. Existing configs are unaffected.
- `> 0`: one connection periodically logs uplink/downlink stats every
  `stats-log-interval` seconds until the connection closes.

To keep log volume bounded, only one connection reports at a time. When the
reporting connection closes, the role is handed off to a waiting connection,
and the role is released via an RAII drop guard so it cannot leak if the
task is cancelled.

## Why periodic instead of on-new-bistream

Link quality is a continuously evolving physical quantity. Sampling it on a
fixed cadence decouples "how often we measure" from "how often the app opens
connections", which is the standard model for health checks and telemetry.
It gives each connection a predictable, bounded stream of samples that
downstream consumers (log parsers, dashboards, scoring/health systems) can
actually rely on.

## Why a single reporter

The original code was already effectively single-stream: a process-global
10s throttle meant at most one log line per 10s regardless of connection
count. Keeping a single reporter preserves that bounded log volume and avoids
flooding the log when many connections are alive. The handoff + RAII guard
only exist so that a plain "first connection wins forever" flag does not
silently stop all logging once that connection closes.

## Backward compatibility

`stats-log-interval` defaults to `0`, which is behavior-identical to today.
Nothing changes unless the option is explicitly set.

## Testing

- `cargo check -p shadowquic` — clean.
- Manually verified with `stats-log-interval: 10`: logs arrive every 10s
  during a long transfer and stop once the connection closes; with the field
  omitted (default 0) behavior matches the previous per-request logging.